### PR TITLE
Update GitHub Actions workflow for image building and add Dockerfile

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,16 +1,12 @@
 name: 'Build Homelab images'
 
 on:
-  pull_request:
-    paths:
-      - 'images/Dockerfile'
   push:
     branches:
-      - main
-    paths:
-      - 'images/Dockerfile'
+      - 'main'
     tags:
       - 'v*'
+  pull_request:
 
 permissions:
   contents: write
@@ -18,14 +14,40 @@ permissions:
   id-token: write
   actions: read
 jobs:
-  build:
-    name: Docker Build
+  base:
+    name: Base Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64, linux/arm64
+          context: ./images
+          file: Dockerfile
+          tags: quay.io/mauromorales/ubuntu:24.04-${{ github.sha }}
+          push: true
+
+  kairos:
+    name: Kairos Factory
+    needs: base
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@main
     secrets:
       registry_username: ${{ secrets.REGISTRY_USERNAME }}
       registry_password: ${{ secrets.REGISTRY_PASSWORD }}
     with:
-      base_image: ubuntu:24.04
+      base_image: quay.io/mauromorales/ubuntu:24.04-${{ github.sha }}
       model: "generic"
       arch: "amd64"
       version: "auto"

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -34,8 +34,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           platforms: linux/amd64, linux/arm64
-          context: ./images
-          file: Dockerfile
+          file: images/Dockerfile
           tags: quay.io/mauromorales/ubuntu:24.04-${{ github.sha }}
           push: true
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Refactor workflow to include a base image build job and a Kairos factory job.
- Update the base image to use the newly built image from Quay.
- Add a Dockerfile for building the Ubuntu 24.04 image with Git installed.