### PR TITLE
docs: add midnight agent-host node README and ADR-001

### DIFF
--- a/docs/adr/ADR-001-agent-host-os.md
+++ b/docs/adr/ADR-001-agent-host-os.md
@@ -1,0 +1,33 @@
+# ADR-001: Agent Host OS — Kairos Ubuntu 24.04 LTS flavor
+
+Date: 2026-07-19
+Status: Accepted
+Deciders: Mauro (with Claude as design assistant)
+
+## Context
+
+The Beelink SER5 mini PC (see `nodes/midnight/README.md` in the homelab repo) is the always-on agent host for a 6-month agentic development experiment. The machine must run unattended, be remotely recoverable, and eventually dogfood Kairos itself ("the AI dev infrastructure runs on the immutable OS it maintains"). The first Kairos milestone is an agent-host image built during vacation weeks 1–2, flashed on return; a later milestone migrates to Hadron.
+
+The host executes a large volume of unattended shell activity: Claude Code sessions, sandboxed bash (bubblewrap), install scripts, CI-adjacent tooling, libvirt/QEMU VMs. The OS layer should be the most boring, most compatible part of the stack — novelty budget is spent elsewhere (orchestration, harness, image pipeline).
+
+Sequencing: Fedora (already installed) serves as interim scaffolding so no pre-departure time is spent reinstalling; the Kairos image replaces it on return.
+
+## Decision
+
+Base the agent-host image on the **Kairos Ubuntu 24.04 LTS flavor**, headless (no GUI — the architecture has no graphical component on this machine).
+
+## Alternatives considered
+
+**Ubuntu 26.04 LTS flavor — rejected for now.** 26.04 (released 2026-04-23) is a deliberately transitional release: sudo-rs replaces sudo as default (known incompatibilities, e.g. missing `--preserve-env`, changed output formats that break script parsing — it broke Git's own CI), Rust coreutils replace most GNU coreutils (~88% GNU test compatibility at release), cgroup v1 removed with no fallback, Python 3.12 → 3.13. An unattended agent host executing thousands of third-party scripts and tutorials' worth of assumptions is the worst possible early adopter for a userland transition. 24.04 is supported into 2029, well beyond the experiment window. A future migration to 26.04 is planned as a documented experiment ("what breaks") once the system is stable — a content opportunity, not a dependency.
+
+**Debian-based flavor — acceptable substitute.** Equally boring userland; not chosen only because the Ubuntu 24.04 flavor is the more exercised path in the Kairos ecosystem. Revisit if flavor maintenance status suggests otherwise.
+
+**Hadron — deferred, not rejected.** Target for a later milestone (~month 4). No package manager means everything must be baked into the image or containerized; a valuable engineering story once the system is stable, a poor week-1 dependency.
+
+**Stay on Fedora (non-Kairos) — rejected as endstate.** Forfeits the dogfooding goal; kept only as interim scaffolding, which also demonstrates portability (the system's identity lives in git — skills, configs, image definitions — not in the host OS).
+
+## Consequences
+
+- The vacation flagship task is building this image: cloud-config baking in the agent user, Claude Code (pinned version), sandbox deps (bubblewrap, socat), Tailscale (pinned, with pre-auth key), gh, worktree layout, masked suspend targets. Iterated in libvirt/QEMU VMs on the SER5; success criterion: flash-and-go on return (~1 hour migration).
+- Version pinning is policy: the image definition pins Claude Code and Tailscale versions explicitly; upgrades are deliberate image rebuilds, not drift.
+- Future ADRs anticipated: PXE/AuroraBoot self-rebuild flow (month 2), trusted boot with fTPM + Secure Boot re-enablement (month 3+), 26.04 migration, Hadron migration (~month 4).

--- a/nodes/midnight/README.md
+++ b/nodes/midnight/README.md
@@ -1,0 +1,92 @@
+# midnight — Beelink SER5 (agent host)
+
+Status: active. Interim OS: Fedora (scaffolding). Target OS: Kairos Ubuntu 24.04 LTS flavor (see [ADR-001](../../docs/adr/ADR-001-agent-host-os.md)), later Hadron.
+Role: always-on agent host for a 6-month agentic development experiment.
+Last updated: 2026-07-19.
+
+## Identity
+
+| Item | Value |
+|---|---|
+| Model | Beelink SER5 (AMD Ryzen, 32 GB RAM) |
+| Hostname | midnight |
+| Primary NIC | `enp1s0` (Realtek, onboard Ethernet) |
+| MAC (WoL target) | redacted — kept in private notes |
+| Boot mode | UEFI |
+| Secure Boot | Disabled |
+
+## BIOS configuration (verified 2026-07-19)
+
+Enter BIOS: press `Del` repeatedly at the Beelink logo. Save & exit: `F4`.
+
+| Setting | Location | Value | Purpose |
+|---|---|---|---|
+| AC Power Loss | Advanced → AMD CBS → FCH Common Options → Ac Power Loss Options | **Always On** | Box boots on any power restoration; enables remote recovery by power-cycling (smart plug / power strip) |
+| Wake (WLAN/WoL power enable) | Advanced → AMD PBS | Enabled | Keeps NIC powered in S5 for Wake-on-LAN |
+| Boot mode | — | UEFI | |
+| Secure Boot | — | Disabled | Fine for now; revisit for the trusted-boot milestone (see below) |
+
+### Boot order (deliberate — do not reorder)
+
+1. SD
+2. USB device
+3. Hard disk: Fedora
+4. CD/DVD
+5. Network: UEFI PXE IPv4
+6. UEFI AP: Built-in EFI Shell
+
+Rationale: disk-first with one-time override. Normal boots never touch PXE (no DHCP timeout, no reinstall footgun). Reinstalls are triggered from inside the OS with `efibootmgr --bootnext <pxe-entry-id>` for a single boot, with AuroraBoot serving the image (month-2 milestone). SD/USB above disk fail through instantly when empty — but **do not leave a bootable USB stick inserted** on an unattended reboot.
+
+The built-in EFI shell (entry 6) is inert in normal operation and only reachable if everything above it fails. It is a recovery asset: it can manually launch `.efi` binaries from disk (`FS0:` then run the binary) or repair boot entries via `bcfg`. Note for the trusted-boot milestone: a firmware shell that launches arbitrary EFI binaries is part of the attack surface; Secure Boot policy must account for it.
+
+### TODO in BIOS (next physical access)
+
+- [ ] Verify SVM (AMD virtualization) is enabled: Advanced → CPU Configuration. Needed for libvirt/QEMU image-build VMs.
+
+## Capabilities discovered
+
+- **PXE boot (UEFI IPv4)**: enables network reinstall of Kairos via AuroraBoot. Target flow (month 2): agent updates image definition → CI builds → start AuroraBoot → `efibootmgr --bootnext <id>` → reboot → box reinstalls itself. Requires DHCP/netboot infra on the LAN; set up while physically home.
+- **fTPM**: available. Enables Kairos trusted boot testing on real hardware (UKI, measured boot, TPM-backed encryption) — month-3+ milestone. Requires re-enabling Secure Boot with enrolled keys; plan a dedicated ADR before touching it.
+
+## Wake-on-LAN
+
+NIC supports magic-packet wake (`Supports Wake-on: pumbg`); ships disabled (`Wake-on: d`).
+
+Enabled live with:
+
+```sh
+sudo ethtool -s enp1s0 wol g
+```
+
+**Persistence (required — ethtool setting resets on reboot).** Via NetworkManager:
+
+```sh
+nmcli -f NAME,DEVICE connection show          # find the connection for enp1s0
+sudo nmcli connection modify "<name>" 802-3-ethernet.wake-on-lan magic
+```
+
+Verify after a cold boot: `sudo ethtool enp1s0 | grep Wake` must show `Wake-on: g`.
+
+Wake from another machine on the LAN:
+
+```sh
+wakeonlan <mac-address>
+```
+
+- [ ] End-to-end test performed from full power-off (S5): PENDING / result: ___
+
+## Host OS notes (Fedora interim)
+
+- SELinux enforcing; clean so far (`sudo ausearch -m avc -ts recent` → no matches). If sandbox/libvirt operations fail mysteriously, check AVC denials before blaming tooling; fix with targeted booleans, do not disable.
+- Installed for Claude Code sandboxing: `bubblewrap`, `socat`.
+- Suspend masked for 24/7 operation:
+
+```sh
+sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
+```
+
+- [ ] Capture `efibootmgr` output here (boot entry IDs, especially the PXE entry, for the BootNext self-rebuild flow):
+
+```
+(paste output)
+```


### PR DESCRIPTION
## Summary

- Add `nodes/midnight/README.md` documenting the Beelink SER5 (**midnight**), the always-on agent host for the 6-month agentic development experiment: identity, verified BIOS/boot-order config, Wake-on-LAN setup, PXE and fTPM capabilities, and Fedora interim-OS notes.
- Add `docs/adr/ADR-001-agent-host-os.md` recording the decision to base the agent-host image on the **Kairos Ubuntu 24.04 LTS flavor** (headless), with alternatives (Ubuntu 26.04, Debian flavor, Hadron, staying on Fedora) considered.

The two docs cross-reference each other; relative links resolve in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)