### PR TITLE
chore: add local git hooks blocking direct main commits/pushes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Blocks commits directly on protected branches (see CLAUDE.md: "never commit to main directly").
+protected_branches="main master"
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+for branch in $protected_branches; do
+  if [ "$current_branch" = "$branch" ]; then
+    echo "error: direct commits to '$branch' are not allowed." >&2
+    echo "       create a branch first: git checkout -b <branch-name>" >&2
+    exit 1
+  fi
+done

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Blocks pushing commits directly onto protected branches (see CLAUDE.md: "never commit to main directly").
+# Catches cases pre-commit can't: merges, cherry-picks, or commits made with --no-verify.
+protected_branches="main master"
+remote="$1"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  branch=$(echo "$remote_ref" | sed -n 's#^refs/heads/##p')
+  for protected in $protected_branches; do
+    if [ "$branch" = "$protected" ]; then
+      echo "error: direct push to '$protected' on '$remote' is not allowed." >&2
+      echo "       open a pull request instead." >&2
+      exit 1
+    fi
+  done
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Replicates the `.githooks/` backstop from the `mission-control` repo into homelab (mission-control issue #4):

- **`pre-commit`** — refuses commits made while on `main`/`master`.
- **`pre-push`** — refuses pushes targeting `main`/`master`, catching cases `pre-commit` can't (merges, cherry-picks, `--no-verify` commits).

Both are committed with the executable bit (`100755`). They are **opt-in per clone** via `git config core.hooksPath .githooks` — already enabled on this machine's clone.

This is belt-and-braces alongside real server-side branch protection (tracked in the companion mission-control issue #5), which matters because this repo is public. Full rationale and known limitations (local-only, opt-in, bypassable with `--no-verify`) are in `docs/adr/ADR-002-local-git-hooks.md` in the mission-control repo.

## Verification

- Hooks tracked as executable (`100755`).
- `core.hooksPath` set on the local clone.
- Confirmed the installed `pre-commit` hook refuses a commit on a protected branch (exit 1 with the guidance message). It takes effect on `main` in each clone once this merges and `.githooks/` is present there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)