### PR TITLE
chore: check in sandbox settings with full-network access

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowedDomains": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a repo-tracked `.claude/settings.json` so **every future session and every machine** inherits the sandbox configuration, rather than depending on the machine-local, git-ignored `.claude/settings.local.json` that the `/sandbox` panel writes.

## Settings set (and why)

| Key | Value | Why |
|---|---|---|
| `sandbox.enabled` | `true` | Turn the Bash sandbox on for this project. |
| `sandbox.autoAllowBashIfSandboxed` | `true` | Auto-allow mode: sandboxed Bash commands run without a permission prompt. (Requirement 1.) |
| `sandbox.network.allowedDomains` | `["*"]` | Allow **all** domains through the built-in sandbox proxy, so network commands run **inside** the sandbox instead of failing the domain check and falling back to unsandboxed execution. (Requirement 2.) |

The exact key names were taken from the current schema: `autoAllowBashIfSandboxed` is what the `/sandbox` Mode tab itself writes, and `sandbox.network.allowedDomains` with a `*` wildcard is the documented way to pre-allow domains (the docs describe `deniedDomains` as overriding "a broader `allowedDomains` wildcard", confirming wildcards including `*` are honored).

## Deliberate deviation from the docs (called out, not silent)

The sandboxing docs **recommend against** broad network access and explicitly warn about it:

> "Allowing broad domains such as `github.com` can create paths for data exfiltration. Because the proxy makes its allow decision from the client-supplied hostname without inspecting TLS, code running inside the sandbox can potentially use domain fronting or similar techniques to reach hosts outside the allowlist."

> "Effective sandboxing requires both filesystem and network isolation. Without network isolation, a compromised agent could exfiltrate sensitive files like SSH keys."

`allowedDomains: ["*"]` therefore effectively **removes network isolation as a preventive boundary** — we keep visibility via the built-in proxy's logging, not prevention. This is an accepted, deliberate tradeoff per the experiment design (full network access + proxy logging over an allowlist). **Filesystem isolation is unchanged** — sandboxed commands still write only to the working dir and temp dir — so we retain that half of the boundary.

Other doc points worth noting:
- The built-in proxy does **not** terminate/inspect TLS by default; we are not setting `network.tlsTerminate` or `httpProxyPort`, so we use the built-in proxy as-is (logging, no content inspection).
- `mask` credential entries and `network.tlsTerminate` are **ignored** when set in a repo's `.claude/settings.json` (honored only from user/managed/CLI settings) — not used here, but relevant if we later want credential masking.
- We are **not** setting `allowUnsandboxedCommands: false`. The escape hatch stays available so genuinely sandbox-incompatible tools (e.g. `docker`) can still run, rather than hard-failing. Opening the network was enough to stop network commands from falling back.
- The same two keys currently also sit in machine-local `settings.local.json` (panel-written); this checked-in file is what makes them repo-wide and portable.

## Note on writing the file

`.claude/settings.json` is deny-listed for **Bash** writes inside the sandbox (self-tamper protection). The file was created with the Write tool, which goes through the permission system rather than the bwrap sandbox, so no unsandboxed-write fallback was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)