### PR TITLE
chore: add conservative Bash permission allow list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,30 @@
     "network": {
       "allowedDomains": ["*"]
     }
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git merge --ff-only:*)",
+      "Bash(git pull --ff-only:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git ls-files:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh issue edit:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh project list:*)",
+      "Bash(gh project view:*)",
+      "Bash(gh project item-list:*)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Mirrors mission-control's permission-friction fix (mission-control#16, PR mission-control#17) into homelab's checked-in `.claude/settings.json`, adding a conservative `permissions.allow` list of safe read/sync command prefixes so recurring session work stops prompting. Closes mission-control#18.

## The base list (from mission-control#17)

`git fetch`, `git checkout`, `git merge --ff-only`, `git status`, `git log`, `git diff`; `gh issue list/view/comment/create/edit`; `gh pr list/view/comment` — all in the `Bash(<cmd>:*)` prefix form, enumerated per-subcommand rather than blanket wildcards.

## Homelab-specific adaptations (the "adapt, don't copy blindly" part)

Reviewing what recent homelab sessions actually hit for unsandboxed-fallback / permission approval, I added these **read-only or safe-sync** commands that recur here and aren't in the mission-control base:

- `git pull --ff-only` — the standard "sync main" step every session; `--ff-only` can't create merge commits or lose work, and plain `git pull` still prompts.
- `git show`, `git rev-parse`, `git ls-files` — read-only inspection used routinely (e.g. comparing a file against `origin/main:<path>`, checking tracked files).
- `gh project list`, `gh project view`, `gh project item-list` — the recurring "check the Mission Control board" activity. Enumerated to the read-only subcommands only, so mutating ones (`item-edit`, `item-delete`, `item-archive`, `edit`, `delete`, `close`) still prompt — same philosophy as the enumerated `gh issue`/`gh pr` entries.

## Explicitly excluded (still prompt, by design)

Kept off the list per mission-control#17's rationale:

- **blanket `git push`** and **`gh pr merge`** — these are the hard-rule-2 boundary; must stay deliberate.
- **`rm`** — destructive.
- **`gh api`** — Claude Code's prefix matching can't distinguish read `gh api` GETs from mutating calls like `gh api graphql -f query='mutation {...}'`; they're shaped identically at the CLI level, so the whole prefix stays gated.
- `git commit` / `git add` — writes; commits also go through the pre-commit hook. Left to the normal flow.

## Notes

- `git commit`/`push` to `main` remain blocked by the local `.githooks` and the server-side ruleset regardless of this list — this only changes *prompting* for already-safe commands, not what's allowed to touch `main`.
- JSON validated; the diff only adds the `permissions.allow` block, leaving the sandbox config untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
