### PR TITLE
docs: add ADR-006, rack switch

### DIFF
--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -26,9 +26,10 @@ switch and then the room switch before it reaches the Deco.
 
 Mauro's stated goal for where things live:
 
-- **The desk** holds only the Mac Mini
+- **The desk** holds only `stardust`
 - **The main power cabinet** holds `thuroros`, which must stay near the doorbell
-- **The rack** holds everything else
+- **The rack** holds everything else, including `polaris`, the Mac Mini that runs
+  [mowa](https://github.com/mauromorales/mowa)
 
 The desk and the rack are physically next to each other, so the order of the two switches
 in the chain is a free choice rather than a constraint.
@@ -38,9 +39,10 @@ in the chain is a free choice rather than a constraint.
 Replace the rack's 5-port with an 8-port, and move the freed 5-port to a dedicated
 physical network for the Kubernetes cluster.
 
-**And retire the desk switch.** With only the Mac Mini left on the desk, a 5-port switch
-would serve a single device. One cable from the rack does the same job with one less box,
-one less power supply and one less hop. The freed 5-port becomes a spare.
+**And retire the desk switch.** With only `stardust` left on the desk, a 5-port switch
+would serve a single device. Either one cable from the rack, or WiFi — see below. Either
+way the switch goes, along with a box, a power supply and a hop. The freed 5-port becomes
+a spare.
 
 ### The port budget for the rack
 
@@ -52,18 +54,26 @@ one less power supply and one less hop. The freed 5-port becomes a spare.
 | 4 | HP ProDesk 600 G4, Kubernetes control plane |
 | 5 | New machine, incoming, Kubernetes worker |
 | 6 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
-| 7 | Mac Mini M2 at the desk, `mowa` and shared storage |
-| 8 | Spare |
+| 7 | `polaris`, Mac Mini M2, runs `mowa` |
+| 8 | Spare, or `stardust` if the desk is wired |
 
-**Seven of eight, with one spare. Eight ports is the right size for the rack.**
+**Seven of eight, and the eighth is optional. Eight ports is the right size for the rack.**
 
-### WiFi for the Mac Mini, considered and rejected
+Note that wiring `stardust` fills the switch. That is acceptable — a spare port is nice,
+not necessary — but it is worth knowing before the decision rather than after.
 
-Mesh coverage at the desk is good, and one machine on WiFi would be acceptable for general
-use. It is rejected because of *which* machine it is: the Mac Mini serves shared storage
-for the lab and is the intended target for Home Assistant's off-box backups. **A backup
-target on variable mesh throughput is a poor foundation, particularly for backups that
-have never been restore-tested.** It sits beside the rack, so a cable costs a cable.
+### WiFi for `stardust` — acceptable
+
+Mesh coverage at the desk is good, and `stardust` is a workstation rather than
+infrastructure. **Nothing in the lab depends on it being reachable**, so variable
+throughput costs its user some convenience and costs the lab nothing.
+
+This is a genuine choice rather than a compromise. Wire it if the desk is tidy enough to
+want one more cable; leave it on WiFi otherwise.
+
+**The reasoning would be different for `polaris`**, which serves `mowa` and may later
+serve shared storage. That machine is in the rack and wired, so the question does not
+arise.
 
 ### PoE belongs on the room switch, not this one
 
@@ -172,6 +182,8 @@ come from somewhere. Replacing it is the reason this ADR exists.
 - The re-cabling removes the desk from the rack's failure path at no cost, and drops the
   chain from three unmanaged hops to two
 - One less box and one less power supply at the desk, and a spare 5-port switch
+- `stardust` on WiFi is a supported outcome rather than a fallback, since nothing in the
+  lab depends on that machine
 
 ### Negative and accepted trade-offs
 
@@ -192,6 +204,8 @@ come from somewhere. Replacing it is the reason this ADR exists.
    come to the rack instead, this ADR changes and PoE returns to the table.
 3. **What happens to the spare 5-port** once the desk switch is retired? A second
    Kubernetes segment and a cold spare are both reasonable. Not decided here.
+4. **Where does shared storage live?** Undecided, and it deserves its own ADR. It is out of
+   scope here, but it could add a device to the rack and therefore claim the spare port.
 
 **Prices are indicative, from August 2026 listings, and were not verified at a Belgian
 retailer.** Confirm locally before ordering.

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -34,6 +34,23 @@ Mauro's stated goal for where things live:
 The desk and the rack are physically next to each other, so the order of the two switches
 in the chain is a free choice rather than a constraint.
 
+```
+router → Deco → 8-port, no PoE ─┬─ thuroros (doorbell)
+                (power cabinet) ├─ … the rooms
+                                │
+                                └─ 8-port, NEW (rack) ─┬─ midnight
+                                                       ├─ HP ProDesk (control plane)
+                                                       ├─ new worker
+                                                       ├─ Home Assistant Pi
+                                                       ├─ polaris (mowa)
+                                                       ├─ 5-port (Kubernetes segment)
+                                                       └─ spare, or stardust
+
+stardust (desk) → WiFi, or a cable to the rack's spare port
+```
+
+The desk switch is gone, and the chain is two hops deep instead of three.
+
 ### What is being proposed
 
 Replace the rack's 5-port with an 8-port, and move the freed 5-port to a dedicated

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -324,9 +324,20 @@ is gone.
 | bol.com BE | €84.00 | Third-party seller, four-day delivery |
 
 **All three are online with delivery. No shelf stock in Ghent was confirmed.** Krefel's
-site returned a server error and Coolblue blocks automated requests, so neither was
-checked; Coolblue has a Ghent store and is worth a phone call if the switch is wanted the
-same day.
+site returned a server error and was not checked.
+
+**Coolblue was checked and does not stock either Easy Smart model.** Its whole 16-port
+TP-Link range is the two extremes, both delivered Monday rather than next day:
+
+| Model | Price | Why not |
+|---|---|---|
+| TL-SG116 | €60 | Unmanaged. Their own listing says "None managed switch". This is the trap below |
+| TL-SG1016PE | €138 | Managed and 16 ports, but €63 of it is PoE at the wrong end of the house |
+| SG2016P / SG2218P | €202 / €259 | Omada tier, far past what the rack justifies |
+
+Worth noting for the PoE question specifically: **buying the PoE model for the rack would
+not bring the camera decision forward at all**, because camera runs terminate at the power
+cabinet. It would be PoE in the one place no camera can reach.
 
 Prices for the alternatives above are from August 2026 listings and are indicative rather
 than checked.

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -225,11 +225,31 @@ Roughly €25 to €35. Solves the VLAN half and fails on the port count, exactl
 LS108G. **This was the recommendation of the previous revision of this ADR**, written
 before the board inventory was known.
 
-### TP-Link TL-SG116E, 16 ports Easy Smart — viable, and about €58
+### TP-Link TL-SG116E, 16 ports Easy Smart desktop — rejected on price and lead time
 
-Functionally equivalent to the recommendation at a lower price. **The difference is form
-factor: it is a desktop unit, not 19-inch rack-mountable.** In a rack that matters more
-than the €15, but not by much. Buy it if the rack has a shelf and the saving is wanted.
+Functionally equivalent to the recommendation, in a smaller desktop case: roughly
+209 × 126 × 26 mm against 294 × 180 × 44 mm.
+
+**The "rack" here is an IKEA shelf, not a 19-inch cabinet**, so the mounting ears are of no
+use and this model should have won. It does not, because of what Belgian retailers
+actually charge on 2026-08-14:
+
+| Model | MediaMarkt.be | Alternate.be |
+|---|---|---|
+| TL-SG1016DE | €74.99, in stock, next day | €79.90, in stock |
+| TL-SG116E | €86.49, marketplace seller, 8–10 days | €79.90, **11 working days** |
+
+**The rack-mount model is cheaper and available now.** An earlier revision of this ADR
+quoted about €58 for the TL-SG116E; that was a non-Belgian listing and it should not have
+been carried into a decision about what to buy here.
+
+Buy this one only if shelf depth rules the larger case out.
+
+### TP-Link TL-SG116, without the E — a trap, not an alternative
+
+Nearly the same name, about €55, and **unmanaged**. No VLANs, so no netboot segment. It
+sits next to the TL-SG116E in search results, which is exactly how it gets bought by
+accident. Named here so that does not happen.
 
 ### TL-SG108PE, 4 PoE+ ports at 64 W — rejected
 

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -22,25 +22,48 @@ hangs off the 8-port because it must sit near the doorbell.
 **This is a daisy chain, not a star.** Every packet leaving the rack crosses the desk
 switch and then the room switch before it reaches the Deco.
 
+### The target layout
+
+Mauro's stated goal for where things live:
+
+- **The desk** holds only the Mac Mini
+- **The main power cabinet** holds `thuroros`, which must stay near the doorbell
+- **The rack** holds everything else
+
+The desk and the rack are physically next to each other, so the order of the two switches
+in the chain is a free choice rather than a constraint.
+
 ### What is being proposed
 
 Replace the rack's 5-port with an 8-port, and move the freed 5-port to a dedicated
-physical network for the Kubernetes cluster. The desk keeps its own 5-port.
+physical network for the Kubernetes cluster.
+
+**And retire the desk switch.** With only the Mac Mini left on the desk, a 5-port switch
+would serve a single device. One cable from the rack does the same job with one less box,
+one less power supply and one less hop. The freed 5-port becomes a spare.
 
 ### The port budget for the rack
 
 | Port | Device |
 |---|---|
-| 1 | Uplink to the desk switch |
+| 1 | Uplink to the 8-port in the power cabinet |
 | 2 | Uplink from the Kubernetes 5-port switch |
 | 3 | Beelink SER5 (`midnight`), the agent host |
 | 4 | HP ProDesk 600 G4, Kubernetes control plane |
 | 5 | New machine, incoming, Kubernetes worker |
-| 6 | Mac Mini M2, `mowa` and shared storage — *if it lives in the rack* |
-| 7 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
+| 6 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
+| 7 | Mac Mini M2 at the desk, `mowa` and shared storage |
 | 8 | Spare |
 
 **Seven of eight, with one spare. Eight ports is the right size for the rack.**
+
+### WiFi for the Mac Mini, considered and rejected
+
+Mesh coverage at the desk is good, and one machine on WiFi would be acceptable for general
+use. It is rejected because of *which* machine it is: the Mac Mini serves shared storage
+for the lab and is the intended target for Home Assistant's off-box backups. **A backup
+target on variable mesh throughput is a poor foundation, particularly for backups that
+have never been restore-tested.** It sits beside the rack, so a cable costs a cable.
 
 ### PoE belongs on the room switch, not this one
 
@@ -57,22 +80,26 @@ for the rack on the strength of it.
 
 Nothing in the rack takes power over Ethernet. The machines there have their own supplies.
 
-### The daisy chain is the more interesting problem
+### The daisy chain is the more interesting problem, and retiring the desk switch solves it
 
-It is worth stating plainly, because it costs more than the choice of switch model:
+The current order is worth stating plainly, because it costs more than the choice of
+switch model:
 
 - **All rack traffic shares one gigabit link through the desk switch.** Cluster traffic and
   storage traffic to the Mac Mini both cross it. The rack is the densest part of the
   network and it sits behind the thinnest link.
-- **The desk is now a dependency of the rack.** Unplugging something at the desk, or
-  knocking the switch's power out, takes the rack with it. A desk is a place where cables
-  get moved.
+- **The desk is a dependency of the rack.** Unplugging something at the desk, or knocking
+  the switch's power out, takes the rack with it. A desk is a place where cables get moved.
 - **Three unmanaged hops** make any future VLAN work harder, because every hop has to pass
   tagged traffic.
 
-**Moving the rack switch to hang directly off the room 8-port, in parallel with the desk
-rather than behind it, costs one cable and no money.** That is a bigger improvement than
-any switch on the shortlist.
+**Retiring the desk switch fixes all three at once**, and it follows from the target layout
+rather than being a separate project: the rack connects straight to the cabinet, and the
+Mac Mini connects to the rack. Two hops instead of three, and the failure path no longer
+runs through a desk.
+
+Reversing the order instead — rack first, desk behind it — would fix the dependency
+direction but keep the extra hop and the extra box, for one device.
 
 ### Managed or not
 
@@ -90,8 +117,9 @@ the only real argument against the plain unmanaged unit.
 **Buy a TP-Link TL-SG108E for the rack: 8 gigabit ports, Easy Smart, no PoE. Roughly €25
 to €35.**
 
-**And re-cable the rack to hang off the room 8-port directly, rather than behind the desk
-switch.** The re-cabling matters more than the model choice and costs one cable.
+**Re-cable the rack to hang off the cabinet 8-port directly, and retire the desk switch.**
+The Mac Mini takes a cable from the rack. The cabling matters more than the model choice
+and costs one cable.
 
 Three reasons:
 
@@ -141,7 +169,9 @@ come from somewhere. Replacing it is the reason this ADR exists.
 - Correct size, with one spare port, at a cost close to Mauro's original proposal
 - VLANs available in front of the cluster when the learning work needs them
 - Same vendor and management model as the existing switches
-- The re-cabling removes the desk from the rack's failure path at no cost
+- The re-cabling removes the desk from the rack's failure path at no cost, and drops the
+  chain from three unmanaged hops to two
+- One less box and one less power supply at the desk, and a spare 5-port switch
 
 ### Negative and accepted trade-offs
 
@@ -156,11 +186,12 @@ come from somewhere. Replacing it is the reason this ADR exists.
 
 ### Open questions
 
-1. **Is the Mac Mini in the rack, or at the desk?** It changes the count from seven to six.
-2. **Can the rack be re-cabled to the room switch directly**, or is the run to the desk
-   the only physical path available?
-3. **Where would camera runs terminate?** Assumed to be the room switch. If they would
+1. **Can the rack be re-cabled to the cabinet directly**, or is the existing run the only
+   physical path available? The port count holds either way; only the hop count changes.
+2. **Where would camera runs terminate?** Assumed to be the cabinet switch. If they would
    come to the rack instead, this ADR changes and PoE returns to the table.
+3. **What happens to the spare 5-port** once the desk switch is retired? A second
+   Kubernetes segment and a cold spare are both reasonable. Not decided here.
 
 **Prices are indicative, from August 2026 listings, and were not verified at a Belgian
 retailer.** Confirm locally before ordering.

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -1,0 +1,171 @@
+# ADR-006: Rack switch
+
+Date: 2026-08-14
+Status: Proposed
+Deciders: Mauro
+Related: [ADR-004](ADR-004-home-automation-platform.md) (cameras and the Zigbee coordinator
+preference), [ADR-005](ADR-005-home-assistant-host.md) (Home Assistant host), [ADR-003](ADR-003-rf-gateway.md)
+(network-attached RF gateway)
+
+## Context
+
+The lab has two 5-port TP-Link unmanaged gigabit switches. Neither supplies PoE. They are
+being given fixed roles:
+
+| Switch | Role |
+|---|---|
+| 5-port, existing | A dedicated physical network for the Kubernetes cluster |
+| 5-port, existing | The desk, so desk devices do not need a run to the rack |
+| **New switch** | **The rack — the aggregation point for everything else** |
+
+This ADR chooses the third one. The two existing switches are staying as they are and are
+not in question.
+
+### The port budget, which is the part that decides this
+
+The rack switch is where everything meets. Counting what terminates there:
+
+| Port | Device |
+|---|---|
+| 1 | Uplink to the router |
+| 2 | Uplink from the desk 5-port switch |
+| 3 | Uplink from the Kubernetes 5-port switch |
+| 4 | Beelink SER5 (`midnight`), the agent host |
+| 5 | HP ProDesk 600 G4, Kubernetes control plane |
+| 6 | New machine, incoming, Kubernetes worker |
+| 7 | Mac Mini M2, `mowa` and shared storage |
+| 8 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
+
+**Eight ports, and every one of them is spoken for before anything new arrives.** That is
+without the doorbell Pi (`thuroros`), without the spare Pi 5, without a laptop plugged in
+temporarily, and without the cameras below. A switch that is full on the day it is
+installed is the wrong switch.
+
+### PoE is not hypothetical here, and two existing ADRs say so
+
+[ADR-004](ADR-004-home-automation-platform.md) lists "one or two security cameras,
+RTSP/ONVIF" under planned devices. Cameras of that class are overwhelmingly PoE, and their
+cable runs terminate at the rack, not at the desk.
+
+The same ADR states a device-selection constraint in writing:
+
+> If Zigbee ever becomes necessary, prefer an Ethernet or PoE coordinator over a USB one,
+> for the same reason ADR-003 chose a network-attached RF gateway.
+
+So the lab has already committed, on paper, to preferring PoE devices where a choice
+exists. **Buying a switch without PoE contradicts the direction of a decision that is
+already recorded**, and the recovery is either injectors or buying the switch twice.
+
+### Managed or not
+
+Nothing in the lab needs VLANs today. Two things soon will:
+
+- **A camera is an untrusted device on your LAN.** ONVIF cameras phone home, ship poor
+  firmware, and are rarely updated. Segmenting them onto their own VLAN is the standard
+  answer and it is much easier to do at install time than to retrofit.
+- **The cluster is a teaching instrument.** VLANs, tagged trunks and port isolation are
+  part of what it is there to teach, and the physical-separation approach chosen for the
+  Kubernetes network only goes so far before it needs a trunk.
+
+TP-Link's "Easy Smart" tier is the relevant one: port-based and tag-based VLANs, QoS,
+IGMP snooping and LAG, configured from a web page. It is not a full managed switch and
+does not pretend to be. For this lab it is the right rung — a full managed switch is more
+CLI than the rack currently justifies.
+
+## Decision
+
+**Buy the [TP-Link TL-SG1016PE](https://www.tp-link.com/us/business-networking/easy-smart-switch/tl-sg1016pe/):
+16 gigabit ports, 8 of them PoE+ with a 150 W budget, Easy Smart management, rack-mountable.**
+
+Three reasons, in order of weight:
+
+1. **Sixteen ports.** Eight is already full, as counted above. Sixteen leaves room for the
+   doorbell Pi, the spare Pi 5, cameras, and whatever gets plugged in for an afternoon.
+2. **PoE where the camera runs land.** 150 W across eight PoE+ ports covers two or three
+   cameras, a PoE Zigbee coordinator and a PoE access point, with room left over.
+3. **It is rack-mountable.** The 8-port alternatives are desktop units. This is a rack.
+
+It also keeps the brand already in use, so the two existing switches and this one behave
+the same way.
+
+## Alternatives considered
+
+### TP-Link LS108G, the original proposal — rejected
+
+[LS108G](https://www.tp-link.com/us/home-networking/8-port-switch/ls108g/): 8 ports,
+unmanaged, no PoE, steel case, roughly €20. It is a well-built and very cheap port
+expander, and as a *desk* switch it would be a fine choice.
+
+Rejected for the rack on three counts, any one of which is sufficient: **it is full on
+day one** by the count above, **it has no PoE** despite ADR-004 planning PoE-class
+devices, and **it has no VLAN support** for the camera segmentation that follows those
+devices. The €20 price is real, but the cost of replacing it in six months is the whole
+€20 plus the swap.
+
+### TP-Link LS108GP — rejected
+
+[LS108GP](https://www.tp-link.com/us/business-networking/soho-switch-poe/ls108gp/): 8
+ports, all PoE+, 62 W budget, unmanaged, roughly €45. Solves PoE and nothing else. Still
+eight ports, still no VLANs.
+
+### TP-Link TL-SG108PE — rejected, and it was the close one
+
+[TL-SG108PE](https://www.tp-link.com/us/business-networking/poe-switch/tl-sg108pe/): 8
+ports with 4 PoE+ at 64 W, Easy Smart, roughly €46 to €63. This solves PoE *and*
+management at a third of the price of the recommendation, and four PoE ports is genuinely
+enough for the planned devices.
+
+**It fails only on the port count** — which is the one axis with no workaround short of
+adding another switch and another hop. Worth reconsidering if the port table above turns
+out to be wrong, in particular if the Kubernetes switch does not uplink to the rack.
+
+### A 16-port switch without PoE — viable if PoE is rejected
+
+If Mauro decides cameras are not happening, a 16-port Easy Smart switch without PoE costs
+substantially less and keeps the port headroom, which is the more important half of this
+decision. **Do not buy an 8-port model in that case** — the port count argument stands on
+its own, independently of PoE.
+
+### A full managed switch — rejected for now
+
+More configuration surface than the rack justifies today, and the Easy Smart tier already
+covers VLANs. Revisit if the cluster work starts to need 802.1X, meaningful L3, or
+per-port policy that a web page cannot express.
+
+## Consequences
+
+### Positive
+
+- The rack has spare ports, so the next device does not force a purchase
+- Camera runs terminate on a switch that can power them, with no injectors
+- Camera and IoT segmentation is available when it is needed, rather than a retrofit
+- Rack-mounted rather than a desktop box balanced on a shelf
+- Same vendor and the same management model as the two existing switches
+
+### Negative and accepted trade-offs
+
+- **Roughly six to eight times the price of the LS108G.** This is the real cost of the
+  decision and it should be weighed as such
+- Sixteen ports and 150 W is more than the lab needs today. That is the point, and it is
+  still overprovisioning
+- PoE switches with a large budget are physically bigger and draw more idle power than a
+  passive 8-port unit. Relevant to [#145](https://github.com/mauromorales/mission-control/issues/145),
+  the UPS sizing ticket, which should measure it rather than assume
+- Easy Smart is a ceiling. If the cluster later needs real managed features, this switch
+  gets replaced rather than upgraded
+
+### Open questions, to be answered before purchase
+
+1. **Does the Kubernetes switch uplink to the rack switch, or is that network truly
+   isolated?** If isolated, the cluster nodes need a second NIC each to reach the
+   internet, and the rack switch needs one port fewer. This changes the port count and it
+   is the assumption most likely to be wrong.
+2. **Do the camera cable runs terminate in the rack?** If they land elsewhere, PoE belongs
+   on a different switch and this decision changes.
+3. **Is `thuroros`, the doorbell Pi, wired to the rack or is it on WiFi?**
+4. **Is there a budget ceiling?** It decides between this recommendation and the
+   TL-SG108PE.
+
+**Prices quoted are from August 2026 European listings and are indicative.** Confirm the
+current price locally before ordering; the euro price for the TL-SG1016PE was not verified
+from a Belgian retailer while writing this.

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -9,163 +9,158 @@ preference), [ADR-005](ADR-005-home-assistant-host.md) (Home Assistant host), [A
 
 ## Context
 
-The lab has two 5-port TP-Link unmanaged gigabit switches. Neither supplies PoE. They are
-being given fixed roles:
+### The network as it actually is
 
-| Switch | Role |
-|---|---|
-| 5-port, existing | A dedicated physical network for the Kubernetes cluster |
-| 5-port, existing | The desk, so desk devices do not need a run to the rack |
-| **New switch** | **The rack — the aggregation point for everything else** |
+```
+router → Deco → 8-port TP-Link, no PoE → 5-port TP-Link, no PoE → 5-port TP-Link, no PoE
+                (distributes to all rooms)  (desk)                  (rack)
+```
 
-This ADR chooses the third one. The two existing switches are staying as they are and are
-not in question.
+Three unmanaged TP-Link switches in series, none with PoE. `thuroros`, the doorbell Pi,
+hangs off the 8-port because it must sit near the doorbell.
 
-### The port budget, which is the part that decides this
+**This is a daisy chain, not a star.** Every packet leaving the rack crosses the desk
+switch and then the room switch before it reaches the Deco.
 
-The rack switch is where everything meets. Counting what terminates there:
+### What is being proposed
+
+Replace the rack's 5-port with an 8-port, and move the freed 5-port to a dedicated
+physical network for the Kubernetes cluster. The desk keeps its own 5-port.
+
+### The port budget for the rack
 
 | Port | Device |
 |---|---|
-| 1 | Uplink to the router |
-| 2 | Uplink from the desk 5-port switch |
-| 3 | Uplink from the Kubernetes 5-port switch |
-| 4 | Beelink SER5 (`midnight`), the agent host |
-| 5 | HP ProDesk 600 G4, Kubernetes control plane |
-| 6 | New machine, incoming, Kubernetes worker |
-| 7 | Mac Mini M2, `mowa` and shared storage |
-| 8 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
+| 1 | Uplink to the desk switch |
+| 2 | Uplink from the Kubernetes 5-port switch |
+| 3 | Beelink SER5 (`midnight`), the agent host |
+| 4 | HP ProDesk 600 G4, Kubernetes control plane |
+| 5 | New machine, incoming, Kubernetes worker |
+| 6 | Mac Mini M2, `mowa` and shared storage — *if it lives in the rack* |
+| 7 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
+| 8 | Spare |
 
-**Eight ports, and every one of them is spoken for before anything new arrives.** That is
-without the doorbell Pi (`thuroros`), without the spare Pi 5, without a laptop plugged in
-temporarily, and without the cameras below. A switch that is full on the day it is
-installed is the wrong switch.
+**Seven of eight, with one spare. Eight ports is the right size for the rack.**
 
-### PoE is not hypothetical here, and two existing ADRs say so
+### PoE belongs on the room switch, not this one
 
-[ADR-004](ADR-004-home-automation-platform.md) lists "one or two security cameras,
-RTSP/ONVIF" under planned devices. Cameras of that class are overwhelmingly PoE, and their
-cable runs terminate at the rack, not at the desk.
-
-The same ADR states a device-selection constraint in writing:
+[ADR-004](ADR-004-home-automation-platform.md) plans "one or two security cameras,
+RTSP/ONVIF", and states a device-selection constraint in writing:
 
 > If Zigbee ever becomes necessary, prefer an Ethernet or PoE coordinator over a USB one,
 > for the same reason ADR-003 chose a network-attached RF gateway.
 
-So the lab has already committed, on paper, to preferring PoE devices where a choice
-exists. **Buying a switch without PoE contradicts the direction of a decision that is
-already recorded**, and the recovery is either injectors or buying the switch twice.
+Both of those devices live in rooms. **Cameras and access points terminate on the 8-port
+that feeds the rooms, and that switch is not the subject of this ADR.** The PoE argument
+is real and it applies elsewhere — recorded here so it is not lost, and so nobody buys PoE
+for the rack on the strength of it.
+
+Nothing in the rack takes power over Ethernet. The machines there have their own supplies.
+
+### The daisy chain is the more interesting problem
+
+It is worth stating plainly, because it costs more than the choice of switch model:
+
+- **All rack traffic shares one gigabit link through the desk switch.** Cluster traffic and
+  storage traffic to the Mac Mini both cross it. The rack is the densest part of the
+  network and it sits behind the thinnest link.
+- **The desk is now a dependency of the rack.** Unplugging something at the desk, or
+  knocking the switch's power out, takes the rack with it. A desk is a place where cables
+  get moved.
+- **Three unmanaged hops** make any future VLAN work harder, because every hop has to pass
+  tagged traffic.
+
+**Moving the rack switch to hang directly off the room 8-port, in parallel with the desk
+rather than behind it, costs one cable and no money.** That is a bigger improvement than
+any switch on the shortlist.
 
 ### Managed or not
 
-Nothing in the lab needs VLANs today. Two things soon will:
+Nothing needs VLANs today. The cluster is a teaching instrument, and VLANs, tagged trunks
+and port isolation are part of what it exists to teach. TP-Link's "Easy Smart" tier adds
+port-based and tag-based VLANs, QoS, IGMP snooping and LAG from a web page, for roughly
+€10 more than the unmanaged equivalent. It is not a full managed switch and does not
+pretend to be.
 
-- **A camera is an untrusted device on your LAN.** ONVIF cameras phone home, ship poor
-  firmware, and are rarely updated. Segmenting them onto their own VLAN is the standard
-  answer and it is much easier to do at install time than to retrofit.
-- **The cluster is a teaching instrument.** VLANs, tagged trunks and port isolation are
-  part of what it is there to teach, and the physical-separation approach chosen for the
-  Kubernetes network only goes so far before it needs a trunk.
-
-TP-Link's "Easy Smart" tier is the relevant one: port-based and tag-based VLANs, QoS,
-IGMP snooping and LAG, configured from a web page. It is not a full managed switch and
-does not pretend to be. For this lab it is the right rung — a full managed switch is more
-CLI than the rack currently justifies.
+Ten euros to keep that door open, on the switch in front of the cluster, is cheap. It is
+the only real argument against the plain unmanaged unit.
 
 ## Decision
 
-**Buy the [TP-Link TL-SG1016PE](https://www.tp-link.com/us/business-networking/easy-smart-switch/tl-sg1016pe/):
-16 gigabit ports, 8 of them PoE+ with a 150 W budget, Easy Smart management, rack-mountable.**
+**Buy a TP-Link TL-SG108E for the rack: 8 gigabit ports, Easy Smart, no PoE. Roughly €25
+to €35.**
 
-Three reasons, in order of weight:
+**And re-cable the rack to hang off the room 8-port directly, rather than behind the desk
+switch.** The re-cabling matters more than the model choice and costs one cable.
 
-1. **Sixteen ports.** Eight is already full, as counted above. Sixteen leaves room for the
-   doorbell Pi, the spare Pi 5, cameras, and whatever gets plugged in for an afternoon.
-2. **PoE where the camera runs land.** 150 W across eight PoE+ ports covers two or three
-   cameras, a PoE Zigbee coordinator and a PoE access point, with room left over.
-3. **It is rack-mountable.** The 8-port alternatives are desktop units. This is a rack.
+Three reasons:
 
-It also keeps the brand already in use, so the two existing switches and this one behave
-the same way.
+1. **Eight ports fits**, with one spare — as counted above.
+2. **No PoE, because nothing in the rack needs it.** Camera and coordinator PoE is a
+   question for the room switch, later, when those devices exist.
+3. **Easy Smart, for about €10 over unmanaged**, so the cluster has VLANs available when
+   the learning work reaches them. This is the only part of the decision that is
+   speculative, and it is the cheapest part.
 
 ## Alternatives considered
 
-### TP-Link LS108G, the original proposal — rejected
+### TP-Link LS108G, Mauro's original proposal — viable, and nearly right
 
 [LS108G](https://www.tp-link.com/us/home-networking/8-port-switch/ls108g/): 8 ports,
-unmanaged, no PoE, steel case, roughly €20. It is a well-built and very cheap port
-expander, and as a *desk* switch it would be a fine choice.
+unmanaged, no PoE, steel case, roughly €20.
 
-Rejected for the rack on three counts, any one of which is sufficient: **it is full on
-day one** by the count above, **it has no PoE** despite ADR-004 planning PoE-class
-devices, and **it has no VLAN support** for the camera segmentation that follows those
-devices. The €20 price is real, but the cost of replacing it in six months is the whole
-€20 plus the swap.
+**The port count judgement was correct.** An earlier draft of this ADR rejected it as
+"full on day one"; that was based on a wrong picture of the topology, which assumed the
+rack switch carried a router uplink. It does not — it carries one uplink to the desk. The
+count is seven of eight.
 
-### TP-Link LS108GP — rejected
+It is rejected only on the VLAN question, and only by about €10. **If VLANs are not
+wanted, buy this one.** It is the same family as the two existing 5-ports and it will
+behave identically.
 
-[LS108GP](https://www.tp-link.com/us/business-networking/soho-switch-poe/ls108gp/): 8
-ports, all PoE+, 62 W budget, unmanaged, roughly €45. Solves PoE and nothing else. Still
-eight ports, still no VLANs.
+### TL-SG108PE, 4 PoE+ ports at 64 W — rejected
 
-### TP-Link TL-SG108PE — rejected, and it was the close one
+Roughly €46 to €63. Nothing in the rack draws PoE, so this is paying for a feature at the
+wrong location. Reconsider it for the **room** switch when cameras arrive.
 
-[TL-SG108PE](https://www.tp-link.com/us/business-networking/poe-switch/tl-sg108pe/): 8
-ports with 4 PoE+ at 64 W, Easy Smart, roughly €46 to €63. This solves PoE *and*
-management at a third of the price of the recommendation, and four PoE ports is genuinely
-enough for the planned devices.
+### TL-SG1016PE, 16 ports with 8 PoE+ — rejected
 
-**It fails only on the port count** — which is the one axis with no workaround short of
-adding another switch and another hop. Worth reconsidering if the port table above turns
-out to be wrong, in particular if the Kubernetes switch does not uplink to the rack.
+Roughly six to eight times the price of the LS108G, for ports the rack does not need and
+PoE at the wrong end of the house. This was the recommendation in the first draft of this
+ADR, before the topology was known. It was wrong.
 
-### A 16-port switch without PoE — viable if PoE is rejected
+### Keep the 5-port in the rack — rejected
 
-If Mauro decides cameras are not happening, a 16-port Easy Smart switch without PoE costs
-substantially less and keeps the port headroom, which is the more important half of this
-decision. **Do not buy an 8-port model in that case** — the port count argument stands on
-its own, independently of PoE.
-
-### A full managed switch — rejected for now
-
-More configuration surface than the rack justifies today, and the Easy Smart tier already
-covers VLANs. Revisit if the cluster work starts to need 802.1X, meaningful L3, or
-per-port policy that a web page cannot express.
+Five ports cannot carry the seven devices listed above, and the Kubernetes switch has to
+come from somewhere. Replacing it is the reason this ADR exists.
 
 ## Consequences
 
 ### Positive
 
-- The rack has spare ports, so the next device does not force a purchase
-- Camera runs terminate on a switch that can power them, with no injectors
-- Camera and IoT segmentation is available when it is needed, rather than a retrofit
-- Rack-mounted rather than a desktop box balanced on a shelf
-- Same vendor and the same management model as the two existing switches
+- Correct size, with one spare port, at a cost close to Mauro's original proposal
+- VLANs available in front of the cluster when the learning work needs them
+- Same vendor and management model as the existing switches
+- The re-cabling removes the desk from the rack's failure path at no cost
 
 ### Negative and accepted trade-offs
 
-- **Roughly six to eight times the price of the LS108G.** This is the real cost of the
-  decision and it should be weighed as such
-- Sixteen ports and 150 W is more than the lab needs today. That is the point, and it is
-  still overprovisioning
-- PoE switches with a large budget are physically bigger and draw more idle power than a
-  passive 8-port unit. Relevant to [#145](https://github.com/mauromorales/mission-control/issues/145),
-  the UPS sizing ticket, which should measure it rather than assume
-- Easy Smart is a ceiling. If the cluster later needs real managed features, this switch
-  gets replaced rather than upgraded
+- **Easy Smart is a ceiling.** If the cluster later needs 802.1X, real L3 or per-port
+  policy, this switch is replaced rather than upgraded
+- **VLAN support in the rack is of limited use while the other three hops are unmanaged.**
+  Tagged traffic has to cross them. It buys isolation *within* the rack now, and a
+  starting point later — not end-to-end segmentation today
+- Roughly €10 more than the unmanaged unit, for a feature that may go unused
+- **No PoE anywhere in the lab, still.** That decision is deferred, not made. It comes due
+  when the first camera is bought, and it lands on the room switch
 
-### Open questions, to be answered before purchase
+### Open questions
 
-1. **Does the Kubernetes switch uplink to the rack switch, or is that network truly
-   isolated?** If isolated, the cluster nodes need a second NIC each to reach the
-   internet, and the rack switch needs one port fewer. This changes the port count and it
-   is the assumption most likely to be wrong.
-2. **Do the camera cable runs terminate in the rack?** If they land elsewhere, PoE belongs
-   on a different switch and this decision changes.
-3. **Is `thuroros`, the doorbell Pi, wired to the rack or is it on WiFi?**
-4. **Is there a budget ceiling?** It decides between this recommendation and the
-   TL-SG108PE.
+1. **Is the Mac Mini in the rack, or at the desk?** It changes the count from seven to six.
+2. **Can the rack be re-cabled to the room switch directly**, or is the run to the desk
+   the only physical path available?
+3. **Where would camera runs terminate?** Assumed to be the room switch. If they would
+   come to the rack instead, this ADR changes and PoE returns to the table.
 
-**Prices quoted are from August 2026 European listings and are indicative.** Confirm the
-current price locally before ordering; the euro price for the TL-SG1016PE was not verified
-from a Belgian retailer while writing this.
+**Prices are indicative, from August 2026 listings, and were not verified at a Belgian
+retailer.** Confirm locally before ordering.

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -190,7 +190,7 @@ the only real argument against the plain unmanaged unit.
 ## Decision
 
 **Buy a TP-Link TL-SG1016DE for the rack: 16 gigabit ports, Easy Smart, no PoE,
-19-inch rack-mountable. Roughly €70 to €80.**
+19-inch rack-mountable. €74.99 at MediaMarkt.be, checked 2026-08-14.**
 
 **Re-cable the rack to hang off the cabinet 8-port directly, and retire the desk switch.**
 The Mac Mini takes a cable from the rack. The cabling matters more than the model choice
@@ -295,5 +295,18 @@ is gone.
 4. **Where does shared storage live?** Undecided, and it deserves its own ADR. It is out of
    scope here, but it could add a device to the rack and therefore claim the spare port.
 
-**Prices are indicative, from August 2026 listings, and were not verified at a Belgian
-retailer.** Confirm locally before ordering.
+### Prices, checked at Belgian retailers on 2026-08-14
+
+| Retailer | Price | Availability |
+|---|---|---|
+| MediaMarkt.be | **€74.99** | Online in stock, next-day if ordered before 23:30 |
+| Alternate.be | €79.90 | In stock |
+| bol.com BE | €84.00 | Third-party seller, four-day delivery |
+
+**All three are online with delivery. No shelf stock in Ghent was confirmed.** Krefel's
+site returned a server error and Coolblue blocks automated requests, so neither was
+checked; Coolblue has a Ghent store and is worth a phone call if the switch is wanted the
+same day.
+
+Prices for the alternatives above are from August 2026 listings and are indicative rather
+than checked.

--- a/docs/adr/ADR-006-rack-switch.md
+++ b/docs/adr/ADR-006-rack-switch.md
@@ -31,6 +31,12 @@ Mauro's stated goal for where things live:
 - **The rack** holds everything else, including `polaris`, the Mac Mini that runs
   [mowa](https://github.com/mauromorales/mowa)
 
+"Everything else" is larger than the servers. The lab also holds, or expects to hold, a
+Raspberry Pi 5, a Radxa board, a work laptop, an NVIDIA Jetson Thor, and a RISC-V board
+once [#99](https://github.com/mauromorales/mission-control/issues/99) picks one. **These
+are not an afterthought — testing Kairos on real boards is the point of the lab**, and
+each one wants a wired port while it is being worked on.
+
 The desk and the rack are physically next to each other, so the order of the two switches
 in the chain is a free choice rather than a constraint.
 
@@ -38,23 +44,29 @@ in the chain is a free choice rather than a constraint.
 router → Deco → 8-port, no PoE ─┬─ thuroros (doorbell)
                 (power cabinet) ├─ … the rooms
                                 │
-                                └─ 8-port, NEW (rack) ─┬─ midnight
-                                                       ├─ HP ProDesk (control plane)
-                                                       ├─ new worker
-                                                       ├─ Home Assistant Pi
-                                                       ├─ polaris (mowa)
-                                                       ├─ 5-port (Kubernetes segment)
-                                                       └─ spare, or stardust
+                                └─ 16-port, NEW (rack) ─┬─ midnight
+                                                        ├─ HP ProDesk (control plane)
+                                                        ├─ new worker
+                                                        ├─ Home Assistant Pi
+                                                        ├─ polaris (mowa)
+                                                        ├─ Jetson Thor
+                                                        ├─ Raspberry Pi 5
+                                                        ├─ Radxa
+                                                        ├─ RISC-V board (planned)
+                                                        ├─ work laptop
+                                                        ├─ 5-port (isolated segment)
+                                                        └─ spare ×4
 
-stardust (desk) → WiFi, or a cable to the rack's spare port
+stardust (desk) → WiFi, or a cable to the rack
 ```
 
 The desk switch is gone, and the chain is two hops deep instead of three.
 
 ### What is being proposed
 
-Replace the rack's 5-port with an 8-port, and move the freed 5-port to a dedicated
-physical network for the Kubernetes cluster.
+Replace the rack's 5-port with a 16-port, and move the freed 5-port to a dedicated
+physical segment — for the Kubernetes cluster, for netboot testing, or as a cold spare.
+That choice is out of scope here.
 
 **And retire the desk switch.** With only `stardust` left on the desk, a 5-port switch
 would serve a single device. Either one cable from the rack, or WiFi — see below. Either
@@ -63,21 +75,35 @@ a spare.
 
 ### The port budget for the rack
 
-| Port | Device |
+**Permanent residents**
+
+| # | Device |
 |---|---|
 | 1 | Uplink to the 8-port in the power cabinet |
-| 2 | Uplink from the Kubernetes 5-port switch |
+| 2 | Uplink from the 5-port on the isolated segment |
 | 3 | Beelink SER5 (`midnight`), the agent host |
 | 4 | HP ProDesk 600 G4, Kubernetes control plane |
 | 5 | New machine, incoming, Kubernetes worker |
 | 6 | Raspberry Pi 4, Home Assistant ([ADR-005](ADR-005-home-assistant-host.md)) |
 | 7 | `polaris`, Mac Mini M2, runs `mowa` |
-| 8 | Spare, or `stardust` if the desk is wired |
+| 8 | NVIDIA Jetson Thor |
 
-**Seven of eight, and the eighth is optional. Eight ports is the right size for the rack.**
+**Boards and machines that come and go**
 
-Note that wiring `stardust` fills the switch. That is acceptable — a spare port is nice,
-not necessary — but it is worth knowing before the decision rather than after.
+| # | Device |
+|---|---|
+| 9 | Raspberry Pi 5 |
+| 10 | Radxa board |
+| 11 | RISC-V board, once [#99](https://github.com/mauromorales/mission-control/issues/99) chooses one |
+| 12 | Work laptop |
+| 13 | `stardust`, if the desk is wired rather than on WiFi |
+
+**Thirteen, against eight ports.** An 8-port switch is not merely tight, it is short by
+five before anything unplanned arrives.
+
+The second group is genuinely intermittent — no more than two or three of those boards are
+usually powered at once — so the honest number is somewhere between nine and thirteen.
+**It is above eight either way, and that is what decides this ADR.**
 
 ### WiFi for `stardust` — acceptable
 
@@ -128,6 +154,28 @@ runs through a desk.
 Reversing the order instead — rack first, desk behind it — would fix the dependency
 direction but keep the extra hop and the extra box, for one device.
 
+### The boards need a network the Deco does not control
+
+This is the part that makes VLAN support concrete rather than speculative.
+
+Kairos boards are provisioned by netboot. AuroraBoot runs on `midnight` and has to serve
+DHCP and TFTP to the machine being installed. **A second DHCP server on the main LAN
+fights the Deco**, and the loser is whichever device asks at the wrong moment — including
+the household ones. So netboot testing wants a segment where `midnight` can serve DHCP
+without touching anything the house depends on.
+
+There are two ways to get one, and the switch choice decides which is available:
+
+- **Physically**, on the freed 5-port switch. Works with any switch, costs a cable, and is
+  limited to five devices.
+- **As a VLAN** on the rack switch, which needs an Easy Smart or better. Any port can join
+  the netboot segment, and it can be changed from a web page rather than by moving cables.
+
+**The second is the reason to pay for management, and it is not hypothetical** — it is how
+the riscv64 and Jetson work will actually be done. Note also that this reframes the
+5-port's role: "the Kubernetes segment" was one candidate use, and an isolated netboot
+segment is another. That choice is out of scope here.
+
 ### Managed or not
 
 Nothing needs VLANs today. The cluster is a teaching instrument, and VLANs, tagged trunks
@@ -141,8 +189,8 @@ the only real argument against the plain unmanaged unit.
 
 ## Decision
 
-**Buy a TP-Link TL-SG108E for the rack: 8 gigabit ports, Easy Smart, no PoE. Roughly €25
-to €35.**
+**Buy a TP-Link TL-SG1016DE for the rack: 16 gigabit ports, Easy Smart, no PoE,
+19-inch rack-mountable. Roughly €70 to €80.**
 
 **Re-cable the rack to hang off the cabinet 8-port directly, and retire the desk switch.**
 The Mac Mini takes a cable from the rack. The cabling matters more than the model choice
@@ -150,28 +198,38 @@ and costs one cable.
 
 Three reasons:
 
-1. **Eight ports fits**, with one spare — as counted above.
+1. **Thirteen devices, and eight ports cannot hold them.** The boards are the lab's
+   purpose, not its overflow.
 2. **No PoE, because nothing in the rack needs it.** Camera and coordinator PoE is a
-   question for the room switch, later, when those devices exist.
-3. **Easy Smart, for about €10 over unmanaged**, so the cluster has VLANs available when
-   the learning work reaches them. This is the only part of the decision that is
-   speculative, and it is the cheapest part.
+   question for the cabinet switch, later, when those devices exist.
+3. **Easy Smart, because netboot needs an isolated segment** and a VLAN gives one on any
+   port without moving cables. This was the speculative part of an earlier draft. It is not
+   speculative any more.
+
+It is also rack-mountable, which the 8-port desktop units are not, and this is a rack.
 
 ## Alternatives considered
 
-### TP-Link LS108G, Mauro's original proposal — viable, and nearly right
+### TP-Link LS108G, Mauro's original proposal — rejected
 
 [LS108G](https://www.tp-link.com/us/home-networking/8-port-switch/ls108g/): 8 ports,
 unmanaged, no PoE, steel case, roughly €20.
 
-**The port count judgement was correct.** An earlier draft of this ADR rejected it as
-"full on day one"; that was based on a wrong picture of the topology, which assumed the
-rack switch carried a router uplink. It does not — it carries one uplink to the desk. The
-count is seven of eight.
+Eight ports against thirteen devices, and no VLAN for the netboot segment. It remains an
+excellent switch for what it is, and the freed 5-port covers the same need more cheaply if
+the answer turns out to be "add another small switch".
 
-It is rejected only on the VLAN question, and only by about €10. **If VLANs are not
-wanted, buy this one.** It is the same family as the two existing 5-ports and it will
-behave identically.
+### TP-Link TL-SG108E, 8 ports Easy Smart — rejected
+
+Roughly €25 to €35. Solves the VLAN half and fails on the port count, exactly like the
+LS108G. **This was the recommendation of the previous revision of this ADR**, written
+before the board inventory was known.
+
+### TP-Link TL-SG116E, 16 ports Easy Smart — viable, and about €58
+
+Functionally equivalent to the recommendation at a lower price. **The difference is form
+factor: it is a desktop unit, not 19-inch rack-mountable.** In a rack that matters more
+than the €15, but not by much. Buy it if the rack has a shelf and the saving is wanted.
 
 ### TL-SG108PE, 4 PoE+ ports at 64 W — rejected
 
@@ -180,21 +238,30 @@ wrong location. Reconsider it for the **room** switch when cameras arrive.
 
 ### TL-SG1016PE, 16 ports with 8 PoE+ — rejected
 
-Roughly six to eight times the price of the LS108G, for ports the rack does not need and
-PoE at the wrong end of the house. This was the recommendation in the first draft of this
-ADR, before the topology was known. It was wrong.
+The same 16 ports as the recommendation, plus PoE at the wrong end of the house, for
+roughly twice the price. **This was the first draft's recommendation, and the port count
+turned out to be right for a reason that draft never gave** — dev boards, not cameras.
+The PoE half is still wrong.
 
 ### Keep the 5-port in the rack — rejected
 
-Five ports cannot carry the seven devices listed above, and the Kubernetes switch has to
-come from somewhere. Replacing it is the reason this ADR exists.
+Five ports cannot carry thirteen devices, and the isolated segment needs a switch of its
+own. Replacing it is the reason this ADR exists.
+
+### Stack two 8-port switches instead — rejected
+
+Two cheap 8-ports cost about the same as one 16-port and give 14 usable ports after the
+link between them. They also add a hop, a second power supply, and a bottleneck on the
+link — and neither would carry VLANs unless both are Easy Smart, at which point the saving
+is gone.
 
 ## Consequences
 
 ### Positive
 
-- Correct size, with one spare port, at a cost close to Mauro's original proposal
-- VLANs available in front of the cluster when the learning work needs them
+- Correct size, with roughly four spare ports, so the next board does not force a purchase
+- A netboot VLAN is available on any port, without a second DHCP server on the household
+  LAN and without moving cables
 - Same vendor and management model as the existing switches
 - The re-cabling removes the desk from the rack's failure path at no cost, and drops the
   chain from three unmanaged hops to two
@@ -209,7 +276,11 @@ come from somewhere. Replacing it is the reason this ADR exists.
 - **VLAN support in the rack is of limited use while the other three hops are unmanaged.**
   Tagged traffic has to cross them. It buys isolation *within* the rack now, and a
   starting point later — not end-to-end segmentation today
-- Roughly €10 more than the unmanaged unit, for a feature that may go unused
+- Roughly €50 to €60 more than Mauro's original proposal. That is the real cost of the
+  decision and it should be weighed as such
+- Sixteen ports draws more idle power than an 8-port unit. Relevant to
+  [#145](https://github.com/mauromorales/mission-control/issues/145), the UPS sizing
+  ticket, which should measure it rather than assume
 - **No PoE anywhere in the lab, still.** That decision is deferred, not made. It comes due
   when the first camera is bought, and it lands on the room switch
 


### PR DESCRIPTION
Adds `docs/adr/ADR-006-rack-switch.md`, Status **Proposed**. Mauro decides.

## The recommendation

**A TP-Link TL-SG108E for the rack** — 8 ports, Easy Smart, no PoE, roughly €25–35.

**Re-cable the rack to hang off the cabinet 8-port directly, and retire the desk switch** — the Mac Mini takes a cable from the rack. That costs one cable and is worth more than any model on the shortlist.

## The network as it actually is

```
router → Deco → 8-port, no PoE → 5-port, no PoE → 5-port, no PoE
                (rooms, thuroros)  (desk)           (rack)
```

Three unmanaged switches in series. **Every packet leaving the rack crosses the desk switch and then the room switch.**

## The target layout

Only the Mac Mini on the desk, `thuroros` in the power cabinet near the doorbell, everything else in the rack. The desk and the rack are next to each other.

**With one device left on the desk, a 5-port switch there serves a single machine.** Retiring it removes a box, a power supply and a hop, and frees a 5-port as a spare. It also fixes the daisy chain: two hops instead of three, and the rack no longer depends on a desk where cables get moved.

**WiFi for the Mac Mini is considered and rejected in the ADR.** Mesh coverage is good, but this is the shared-storage host and the intended target for Home Assistant's off-box backups — backups that have never been restore-tested. It sits beside the rack, so a cable costs a cable.

## Port count: seven of eight

Uplink to the cabinet, the Kubernetes 5-port, `midnight`, the control plane, the incoming worker, the Home Assistant Pi, the Mac Mini. One spare.

**Eight ports is the right size.** Mauro's judgement on this was correct.

## Why no PoE

ADR-004 plans RTSP/ONVIF cameras and prefers a PoE or Ethernet Zigbee coordinator over USB. Both of those live in rooms, so **their runs terminate on the 8-port that feeds the rooms — not the rack.** Nothing in the rack draws power over Ethernet; the machines there have their own supplies.

The PoE argument is recorded in the ADR so it is not lost. It comes due when the first camera is bought, and it lands on a different switch.

## Why Easy Smart rather than unmanaged

About €10 for port-based and tag-based VLANs, QoS and LAG, on the switch sitting in front of the cluster. The cluster is a teaching instrument and VLANs are part of what it teaches.

The ADR states the limit of this honestly: **while the other three hops stay unmanaged, VLAN support in the rack buys isolation within the rack and a starting point later — not end-to-end segmentation.**

## What the ADR rejects

- **LS108G**, Mauro's original proposal — **viable, not rejected.** If VLANs are not wanted, buy it. It loses by about €10 on one speculative feature
- **TL-SG108PE** — PoE at the wrong location. Reconsider for the *room* switch when cameras arrive
- **TL-SG1016PE** — ports the rack does not need and PoE at the wrong end of the house
- **Keeping the 5-port** — cannot carry seven devices

## Note on the first draft

The first version of this ADR recommended the TL-SG1016PE and rejected the LS108G as "full on day one". **That was wrong.** It assumed the rack switch carried a router uplink and that camera runs terminated in the rack. Mauro then described the real topology and both assumptions failed. The rewrite is in the second commit; the history shows what changed and why.

## Three open questions

1. **Can the rack be re-cabled to the cabinet directly**, or is the existing run the only physical path? The port count holds either way; only the hop count changes.
2. **Where would camera runs terminate?** Assumed the cabinet switch. If the rack, PoE returns to the table.
3. **What happens to the spare 5-port** once the desk switch is retired? Not decided here.

**Prices are indicative and were not verified at a Belgian retailer.**
