### PR TITLE
docs: add ADR-007, where homelab images get built

### DIFF
--- a/docs/adr/ADR-007-build-pipeline-and-runners.md
+++ b/docs/adr/ADR-007-build-pipeline-and-runners.md
@@ -53,38 +53,55 @@ Checked 2026-08-14.
 
 ## Decision
 
-**Run the builds on self-hosted runners, in a VM on `midnight`, keeping GitHub Actions as
-the pipeline. Keep `homelab` public for now, and revisit visibility only after the runners
-work and storage has been measured.**
+**Keep GitHub-hosted runners for as long as the repository is public. Change nothing about
+the pipeline.**
 
-Sequenced, so each step is provable before the next one starts:
+**Pursue the dogfooding separately, by building an image by hand on `midnight`** — the
+`docker build` stage, then the factory stage through AuroraBoot — and write down what that
+takes. That is the user path. A self-hosted runner is not.
 
-1. **One amd64 runner, in a VM on `midnight`.** Change `runs-on` for the amd64 jobs and
-   prove a build produces the same artifact as the hosted pipeline does.
-2. **One arm64 runner on the spare Raspberry Pi 5**, so `thuroros` builds natively. Move it
-   to the Jetson Thor when that machine lands, since the Thor is the faster arm64 builder.
-3. **Measure the artifact storage** a full release actually consumes.
-4. **Only then re-open the visibility question**, with numbers rather than an assumption.
+### Why a self-hosted runner is the wrong tool for the stated goal
 
-### The runner goes in a VM, not on the host
+An earlier draft of this ADR recommended self-hosted runners in a VM, on dogfooding
+grounds. **That reasoning does not hold**, and the objection is Mauro's:
 
-**A runner executes whatever the workflow says.** `midnight` holds `mauro-agent`'s
-credentials, every clone, and the agent sessions themselves. A private repository with no
-fork pull requests makes the risk small, but "small" is not "absent", and the isolation is
-cheap.
+- **On cost, it buys nothing.** Hosted runners are already free on a public repository.
+- **On dogfooding, it buys almost nothing.** A self-hosted runner executes the same
+  workflow, calling the same reusable factory workflow, with the same inputs. It moves the
+  compute and changes nothing a Kairos user would experience. The differences are disk
+  size, preinstalled tooling and Docker version — real, but not the thing worth testing.
+- **It adds a failure mode**: "the build did not run because the VM was off."
 
-This also agrees with the machine-level rule that the host is not reconfigured for
-experiments. A VM is a thing that can be deleted; a runner installed on the host is not.
+**The genuinely untested path is the one `AGENTS.md` already names**: the factory stage is
+"CI-only; there is no simple local equivalent". That sentence is the dogfooding target. A
+runner leaves it exactly as untested as it is today, because the runner still invokes the
+CI path.
+
+### When this decision changes
+
+Three triggers, any one of which makes self-hosted runners the right answer:
+
+1. **The repository goes private.** Hosted minutes and hosted arm64 both start being
+   billed. This is the only trigger that is about money.
+2. **Hosted runners hit their limits.** Image builds are large and hosted runners ship
+   about 14 GB of free disk. If builds start failing on space, or take long enough to
+   obstruct iteration, self-hosting is the fix.
+3. **The cluster exists and can host CI**, at which point the interesting move is
+   Kubernetes-native rather than a self-hosted GitHub runner — see below.
+
+Until one of those happens, this ADR's answer is to leave a working, free pipeline alone.
 
 ## Alternatives considered
 
-### Keep GitHub-hosted runners and keep the repository public — the status quo
+### Self-hosted runners in a VM on `midnight` — rejected for now, and it was the first draft's recommendation
 
-Free, working, and zero effort. It is a perfectly good answer to the *cost* question and no
-answer at all to the *dogfooding* one, which is the motivation that matters more. It also
-leaves the visibility question permanently blocked.
+Correct for a private repository, and premature for a public one. The reasoning is in the
+Decision section above, because the rejection is the substance of this ADR rather than a
+footnote to it.
 
-Worth stating: **nothing is broken today.** This ADR is not fixing a failure.
+Keep the shape in mind for when a trigger fires: a VM rather than the host, because a
+runner executes whatever the workflow says and `midnight` holds `mauro-agent`'s
+credentials and every clone. That constraint does not expire.
 
 ### Forgejo or Gitea Actions, self-hosted — rejected, and not on technical grounds
 
@@ -132,29 +149,25 @@ worth moving.
 
 ### Positive
 
-- The factory runs on Mauro's own hardware, which is the user path and where upstream bugs
-  will surface
-- Native arm64 builds instead of hosted arm64 runners
-- The visibility question becomes answerable rather than permanently blocked
-- No workflow rewrite. `runs-on` labels change; the rest stands
-- A first, well-scoped use for the Jetson Thor
+- Nothing to build, maintain, or keep switched on. The pipeline that works keeps working
+- The dogfooding effort points at the part that is actually untested — the local factory
+  path — instead of at a runner that would still call CI
+- The triggers for revisiting are written down, so the question returns on evidence rather
+  than on a hunch
 
 ### Negative and accepted trade-offs
 
-- **Builds now depend on machines being up.** A hosted runner is somebody else's problem;
-  a self-hosted one is not. Expect the failure mode "the build did not run because the VM
-  was off"
-- Two runners to maintain, on two architectures
-- A VM on `midnight` consumes memory that the agent sessions currently have
-- **Storage may still be billed** if the repository goes private, and that is unmeasured
-- Kubernetes-native CI is deferred, so the GitOps ambition is recorded rather than met
+- **The visibility question stays blocked**, and that is now explicit rather than implied:
+  going private means solving arm64 and storage first
+- No progress toward the GitOps and Kubernetes-native ambition. Recorded, not met
+- Builds keep depending on GitHub. If hosted runners change terms again, this ADR is what
+  gets re-read
 
 ### Open questions
 
-1. **How much artifact storage does a full release consume?** This decides whether the
-   visibility question is actually unblocked. Measure before deciding.
-2. **Does the Pi 5 have the disk and memory to build an image?** If not, arm64 waits for
-   the Thor and `thuroros` keeps using the hosted arm64 runner while the repository stays
-   public.
-3. **Where does the runner VM's storage live**, given that shared storage is itself
-   undecided?
+1. **Can the factory stage be run locally at all, and what does it take?** This is the
+   dogfooding question, and it is worth a real attempt regardless of what CI does.
+2. **How much artifact storage does a full release consume?** Only matters if trigger 1
+   fires, and it should be measured before that decision rather than during it.
+3. **Are hosted runners close to their disk limit today?** If a build is already near
+   14 GB, trigger 2 is nearer than it looks.

--- a/docs/adr/ADR-007-build-pipeline-and-runners.md
+++ b/docs/adr/ADR-007-build-pipeline-and-runners.md
@@ -1,0 +1,160 @@
+# ADR-007: Where homelab images get built
+
+Date: 2026-08-14
+Status: Proposed
+Deciders: Mauro
+Related: [ADR-001](ADR-001-agent-host-os.md) (the agent host), [ADR-006](ADR-006-rack-switch.md)
+(rack switch and the netboot segment)
+
+## Context
+
+Every node image is built in GitHub Actions: four `build-<node>.yaml` workflows for
+testing, and `release.yaml` for tagged releases. All of them run on GitHub-hosted runners,
+and two jobs — `thuroros` and one release job — run on `ubuntu-24.04-arm`.
+
+**This is free today only because the repository is public.**
+
+Two separate motivations push at it.
+
+### Motivation 1: keeping the option to make the repository private
+
+An earlier plan to make `homelab` private was dropped, partly because GitHub-hosted
+minutes would start being billed. That objection is answerable, and it should be answered
+rather than left as a permanent veto on the visibility question.
+
+### Motivation 2: dogfooding, which is the better reason
+
+Mauro maintains Kairos. **A Kairos maintainer building Kairos images on his own hardware
+is the user path**, and the GitHub-hosted pipeline hides every problem that path has. Bugs
+found by running the factory locally are upstream tickets, which is the point of the
+experiment rather than a side effect.
+
+There is a further ambition attached: a build pipeline that is GitOps-shaped and
+Kubernetes-native, rather than a hosted CI product.
+
+### What was verified, and what was not
+
+**Self-hosted runners are free.** GitHub's billing documentation states that "GitHub
+Actions usage is free for self-hosted runners and for public repositories", and
+self-hosted minutes do not count against the included quota on private repositories.
+Checked 2026-08-14.
+
+**Two costs survive that**, and both are specific to this repository rather than general:
+
+1. **The arm64 jobs.** `runs-on: ubuntu-24.04-arm` is a GitHub-hosted arm64 runner. Those
+   are free for public repositories and billed for private ones. Self-hosting arm64 needs
+   arm64 hardware: the spare Raspberry Pi 5 now, the Jetson Thor when it arrives.
+2. **Artifact storage.** Every build passes `summary_artifacts: true`, and OS images are
+   measured in gigabytes. Included artifact storage is 500 MB on Free and 1 GB on Pro,
+   **shared with GitHub Packages**. Free compute does not imply free storage. **This one is
+   not fully established** — the documentation was ambiguous on whether artifacts produced
+   by self-hosted runners are exempt, so it must be measured on the real billing page
+   before anyone relies on it.
+
+## Decision
+
+**Run the builds on self-hosted runners, in a VM on `midnight`, keeping GitHub Actions as
+the pipeline. Keep `homelab` public for now, and revisit visibility only after the runners
+work and storage has been measured.**
+
+Sequenced, so each step is provable before the next one starts:
+
+1. **One amd64 runner, in a VM on `midnight`.** Change `runs-on` for the amd64 jobs and
+   prove a build produces the same artifact as the hosted pipeline does.
+2. **One arm64 runner on the spare Raspberry Pi 5**, so `thuroros` builds natively. Move it
+   to the Jetson Thor when that machine lands, since the Thor is the faster arm64 builder.
+3. **Measure the artifact storage** a full release actually consumes.
+4. **Only then re-open the visibility question**, with numbers rather than an assumption.
+
+### The runner goes in a VM, not on the host
+
+**A runner executes whatever the workflow says.** `midnight` holds `mauro-agent`'s
+credentials, every clone, and the agent sessions themselves. A private repository with no
+fork pull requests makes the risk small, but "small" is not "absent", and the isolation is
+cheap.
+
+This also agrees with the machine-level rule that the host is not reconfigured for
+experiments. A VM is a thing that can be deleted; a runner installed on the host is not.
+
+## Alternatives considered
+
+### Keep GitHub-hosted runners and keep the repository public — the status quo
+
+Free, working, and zero effort. It is a perfectly good answer to the *cost* question and no
+answer at all to the *dogfooding* one, which is the motivation that matters more. It also
+leaves the visibility question permanently blocked.
+
+Worth stating: **nothing is broken today.** This ADR is not fixing a failure.
+
+### Forgejo or Gitea Actions, self-hosted — rejected, and not on technical grounds
+
+Attractive: full independence from GitHub billing, a forge that fits the GitOps direction,
+and Actions-compatible workflows.
+
+**It conflicts with how this project is reviewed.** Pull requests on GitHub are the review
+loop — the steering repository's own rules make every change a PR because that is how
+Mauro reviews from a phone. Moving the forge moves that loop to a service that has to be
+reachable, backed up, and maintained by the person who is also the only reviewer.
+
+**A self-hosted forge is a bigger commitment than a self-hosted runner, and it is a
+different decision.** If it is wanted later, it deserves its own ADR rather than arriving
+as a side effect of a CI change. Note that Gitea's runner could be adopted without moving
+the forge, which is the cheap half of this idea.
+
+### Kubernetes-native CI — Tekton, Argo Workflows, or similar — deferred, not rejected
+
+**This is the stated destination**, and it cannot be built yet. The cluster does not exist:
+[ADR-005](ADR-005-home-assistant-host.md) records that as a live fact, and it is why the
+Kubernetes learning work was pointed at Immich and Frigate rather than at household
+control.
+
+Two things to know before it is attempted:
+
+- **Image builds want privileged containers.** Building OS images inside Kubernetes is not
+  the gentle first workload for a new cluster.
+- **A build pipeline that lives on the cluster cannot easily build the cluster's own
+  nodes.** Bootstrapping order matters here in a way it does not for an application.
+
+**Revisit when the cluster is multi-node and is no longer the thing being deliberately
+broken** — the same condition [ADR-005](ADR-005-home-assistant-host.md) set for moving
+Home Assistant onto it.
+
+### Build locally with scripts and no CI at all — rejected
+
+The simplest form of "build locally", and it removes more than it saves: no per-pull-request
+validation, and no signal when a Dependabot bump breaks a base image. It replaces a
+pipeline with remembering to run one.
+
+**Self-hosted runners keep the pipeline and move only the compute**, which is the part
+worth moving.
+
+## Consequences
+
+### Positive
+
+- The factory runs on Mauro's own hardware, which is the user path and where upstream bugs
+  will surface
+- Native arm64 builds instead of hosted arm64 runners
+- The visibility question becomes answerable rather than permanently blocked
+- No workflow rewrite. `runs-on` labels change; the rest stands
+- A first, well-scoped use for the Jetson Thor
+
+### Negative and accepted trade-offs
+
+- **Builds now depend on machines being up.** A hosted runner is somebody else's problem;
+  a self-hosted one is not. Expect the failure mode "the build did not run because the VM
+  was off"
+- Two runners to maintain, on two architectures
+- A VM on `midnight` consumes memory that the agent sessions currently have
+- **Storage may still be billed** if the repository goes private, and that is unmeasured
+- Kubernetes-native CI is deferred, so the GitOps ambition is recorded rather than met
+
+### Open questions
+
+1. **How much artifact storage does a full release consume?** This decides whether the
+   visibility question is actually unblocked. Measure before deciding.
+2. **Does the Pi 5 have the disk and memory to build an image?** If not, arm64 waits for
+   the Thor and `thuroros` keeps using the hosted arm64 runner while the repository stays
+   public.
+3. **Where does the runner VM's storage live**, given that shared storage is itself
+   undecided?

--- a/docs/adr/ADR-007-build-pipeline-and-runners.md
+++ b/docs/adr/ADR-007-build-pipeline-and-runners.md
@@ -29,6 +29,9 @@ is the user path**, and the GitHub-hosted pipeline hides every problem that path
 found by running the factory locally are upstream tickets, which is the point of the
 experiment rather than a side effect.
 
+**Note that this motivation is about building locally, not about where CI runs.** The
+Decision section separates the two, and that separation is the substance of this ADR.
+
 There is a further ambition attached: a build pipeline that is GitOps-shaped and
 Kubernetes-native, rather than a hosted CI product.
 
@@ -136,14 +139,15 @@ Two things to know before it is attempted:
 broken** — the same condition [ADR-005](ADR-005-home-assistant-host.md) set for moving
 Home Assistant onto it.
 
-### Build locally with scripts and no CI at all — rejected
+### Replacing CI with local scripts — rejected
 
-The simplest form of "build locally", and it removes more than it saves: no per-pull-request
-validation, and no signal when a Dependabot bump breaks a base image. It replaces a
-pipeline with remembering to run one.
+*Replacing* is the word doing the work. Building by hand as a dogfooding exercise is the
+decision above; making it the only way images get built is a different proposal, and it
+removes more than it saves: no per-pull-request validation, and no signal when a Dependabot
+bump breaks a base image. It swaps a pipeline for remembering to run one.
 
-**Self-hosted runners keep the pipeline and move only the compute**, which is the part
-worth moving.
+**Build locally to learn what the local path costs. Keep CI to catch regressions.** The two
+are not in competition.
 
 ## Consequences
 


### PR DESCRIPTION
Adds `docs/adr/ADR-007-build-pipeline-and-runners.md`, Status **Proposed**. Mauro decides.

## Decision: change nothing about CI. Build locally by hand, separately.

**Keep GitHub-hosted runners for as long as the repository is public.** Pursue the dogfooding by building an image by hand on `midnight` — `docker build`, then the factory stage through AuroraBoot — and write down what that takes.

## This reverses the first draft, and Mauro's objection is why

The first draft recommended self-hosted runners in a VM, on dogfooding grounds. He asked why he would add his own runners while the repo is public. There is no good answer:

- **On cost, it buys nothing.** Hosted runners are already free on a public repository
- **On dogfooding, it buys almost nothing.** A self-hosted runner executes the same workflow, calling the same reusable factory workflow, with the same inputs. It moves the compute and changes nothing a Kairos user would experience
- **It adds a failure mode**: "the build did not run because the VM was off"

**The genuinely untested path is the one `AGENTS.md` already names** — the factory stage is *"CI-only; there is no simple local equivalent"*. That sentence is the dogfooding target, and a runner leaves it exactly as untested, because the runner still invokes the CI path.

The first draft conflated *building locally* with *where CI runs*. Separating them is the substance of this ADR.

## What was verified

**Self-hosted runners are free.** GitHub's billing docs: *"GitHub Actions usage is free for self-hosted runners and for public repositories."* Checked 2026-08-14. The sense that something changed is probably GitHub-hosted **larger** runners, which are paid, and hosted **arm64**, which went free for public repos only.

Two costs would survive that if the repo ever goes private, both specific to this repo:

1. **`runs-on: ubuntu-24.04-arm`** on `thuroros` and one release job — hosted arm64, billed on private repos. Self-hosting arm64 needs arm64 hardware
2. **`summary_artifacts: true`** on every build, with gigabyte images, against 500 MB included on Free and 1 GB on Pro, shared with Packages. **Recorded as unmeasured rather than asserted** — the docs were ambiguous and this needs a real number

## Three triggers to revisit

1. The repository goes private — the only trigger about money
2. Hosted runners hit their limits, roughly 14 GB of free disk, or get slow enough to obstruct iteration
3. The cluster exists and can host CI — at which point Kubernetes-native is the interesting move, not a self-hosted GitHub runner

## Also rejected

- **Forgejo or Gitea as the forge** — on a non-technical ground. GitHub pull requests are this project's review loop. The runner half can be adopted without moving the forge
- **Kubernetes-native CI** — the stated destination, deferred. The cluster does not exist, image builds want privileged containers, and a pipeline on the cluster cannot easily build the cluster's own nodes
- **Replacing CI with local scripts** — build locally to learn what it costs, keep CI to catch regressions. They are not in competition

The VM constraint is kept on record for the day a trigger fires: a runner executes whatever the workflow says, and `midnight` holds `mauro-agent`'s credentials and every clone.