### PR TITLE
docs: record midnight, polaris and homeassistant as running machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This lab is my personal sandbox for exploring OS design, Kubernetes architecture
 
 | Device | Name | Role in Lab | Status | CPU | GPU | Memory | Storage |
 | ------ | ---- | ----------- | ------ | --- | --- | ------ | ------- |
-| Beelink SER5 | [`midnight`](./nodes/midnight/README.md) | Always-on agent host | Running | AMD Ryzen | Integrated Radeon | 32 GB | TBC |
+| Beelink SER5 | [`midnight`](./nodes/midnight/README.md) | Always-on agent host | Running | Ryzen 7 5825U, 8C/16T | Radeon (integrated) | 64 GB DDR4-3200 | 1 TB NVMe SSD |
 | HP ProDesk 600 G4 Mini | TBC | Control Plane & Worker | Planned | Core i5-8500T (8th Gen) 2.1 GHz | Intel UHD Graphics 630 | 16 GB | 256 GB SSD |
 | Mac Mini | `polaris` | iCloud Supporting Services | Running | M2 | M2 | 8G | 256 GB SSD |
 | Raspberry Pi 4 | [`thuroros`](./nodes/thuroros/README.md) | Doorbell relay | Running | ARM Cortex-A72 | Whatever comes in the Pi | 8G | SD Card |

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ This lab is my personal sandbox for exploring OS design, Kubernetes architecture
 
 ## Hardware
 
-| Device | Role in Lab | CPU | GPU | Memory | Storage |
-| ------ | ----------- | --- | --- | ------ | ------- |
-| HP ProDesk 600 G4 Mini | Control Plane & Worker | Core i5-8500T (8th Gen) 2.1 GHz | Intel UHD Graphics 630 | 16 GB | 256 GB SSD |
-| Mac Mini | iCloud Supporing Services | M2 | M2 | 8G | 256 GB SSD |
-| Raspberry Pi 4 | Doorbell relay (`thuroros`) | ARM Cortex-A72 | Whatever comes in the Pi | 8G | SD Card |
-| Raspberry Pi 4 | Home Assistant host (see ADR-005) | ARM Cortex-A72 | Whatever comes in the Pi | 8G | USB SSD |
-| Raspberry Pi 5 | Spare | ARM Cortex-A76 | Whatever comes in the Pi | TBC | TBC |
+| Device | Name | Role in Lab | Status | CPU | GPU | Memory | Storage |
+| ------ | ---- | ----------- | ------ | --- | --- | ------ | ------- |
+| Beelink SER5 | [`midnight`](./nodes/midnight/README.md) | Always-on agent host | Running | AMD Ryzen | Integrated Radeon | 32 GB | TBC |
+| HP ProDesk 600 G4 Mini | TBC | Control Plane & Worker | Planned | Core i5-8500T (8th Gen) 2.1 GHz | Intel UHD Graphics 630 | 16 GB | 256 GB SSD |
+| Mac Mini | `polaris` | iCloud Supporting Services | Running | M2 | M2 | 8G | 256 GB SSD |
+| Raspberry Pi 4 | [`thuroros`](./nodes/thuroros/README.md) | Doorbell relay | Running | ARM Cortex-A72 | Whatever comes in the Pi | 8G | SD Card |
+| Raspberry Pi 4 | `homeassistant` | Home Assistant host | Running | ARM Cortex-A72 | Whatever comes in the Pi | 8G | USB SSD |
+| Raspberry Pi 5 | TBC | Not yet assigned | Spare | ARM Cortex-A76 | Whatever comes in the Pi | TBC | TBC |
+
+Four machines are up today: `midnight`, `polaris`, `thuroros` and `homeassistant`. Only `thuroros` runs an OS built from this repository—`midnight` runs Fedora as scaffolding while its Kairos image is built, `polaris` runs macOS, and `homeassistant` runs Home Assistant OS.
 
 ## Platform Infrastructure
 
@@ -63,6 +66,8 @@ Kairos Factory produces two artifacts per build:
 
 Only **ThurorOS** is currently built by the [release pipeline](./.github/workflows/release.yaml); the other nodes are on hold until they have been tested.
 
+This table is about the images I build here, not about every machine that is up. The other running machines—`midnight`, `polaris` and `homeassistant`—boot an OS that comes from somewhere else, and the hardware table above is the place to look for them.
+
 More on this topic: [What Are Special-Purpose Operating Systems in the Cloud-Native World?](https://www.mauromorales.com/2025/04/16/what-are-special-purpose-operating-systems-in-the-cloud-native-world/)
 
 ### Kubernetes Distribution & Container Runtime
@@ -80,7 +85,7 @@ For now, I stick to the defaults that come with K0s to keep the learning curve s
 At the moment, only one:
 
 - **[mowa](https://github.com/mauromorales/mowa)** — sends notifications through Apple Messages and provides simple shared storage outside the cluster.  
-  Runs on a Mac Mini M2 (8 GB RAM).
+  Runs on `polaris`, the Mac Mini M2 (8 GB RAM). `thuroros` reaches it at `polaris.local`.
 
 ## Related Writings
 

--- a/nodes/midnight/README.md
+++ b/nodes/midnight/README.md
@@ -2,13 +2,16 @@
 
 Status: active. Interim OS: Fedora (scaffolding). Target OS: Kairos Ubuntu 24.04 LTS flavor (see homelab ADR-001, in the private steering repository), later Hadron.
 Role: always-on agent host for a 6-month agentic development experiment.
-Last updated: 2026-07-19.
+Last updated: 2026-08-14.
 
 ## Identity
 
 | Item | Value |
 |---|---|
-| Model | Beelink SER5 (AMD Ryzen, 32 GB RAM) |
+| Model | Beelink SER5 |
+| CPU | AMD Ryzen 7 5825U, 8 cores / 16 threads, Radeon integrated graphics |
+| Memory | 64 GB DDR4-3200 (2 × 32 GB) |
+| Storage | 1 TB NVMe SSD (Transcend TS1TMTE220S) |
 | Hostname | midnight |
 | Primary NIC | `enp1s0` (Realtek, onboard Ethernet) |
 | MAC (WoL target) | redacted — kept in private notes |


### PR DESCRIPTION
The README said one machine was in service: `thuroros`. Three more are running, and none of them appeared as such.

## What changes

- The hardware table gets a **Name** column and a **Status** column.
- **Beelink SER5 (`midnight`) is added.** It was not in the table at all.
- `polaris`, `thuroros` and `homeassistant` are marked Running. The HP ProDesk is Planned, the Pi 5 is Spare.
- A line under the table says which four machines are up, and which OS each one runs.
- The OS image table gets a note. It tracks the images this repo builds, not every machine. The two tables were easy to read as one, which is how `thuroros` looked like the whole lab.
- `mowa` is now named against `polaris` in Supporting Services.
- Drops `(see ADR-005)` from the table. That link broke when the ADRs moved to the steering repo in #38.

## Notes

- The Home Assistant Pi is named `homeassistant`, from `homeassistant.local` in `docs/ha-os-rpi4-boot.md`.
- The Beelink storage size is `TBC`. It is not recorded anywhere I can read.
- Nothing private is added: no addresses, no user names, no host configuration.