### PR TITLE
feat(thuroros): publish the doorbell to Home Assistant over MQTT

### DIFF
--- a/nodes/thuroros/Dockerfile
+++ b/nodes/thuroros/Dockerfile
@@ -13,4 +13,5 @@ RUN apt-get update && apt-get install -y \
     python3-lgpio \
     python3-requests \
     python3-tz \
+    python3-paho-mqtt \
     && rm -rf /var/lib/apt/lists/*

--- a/nodes/thuroros/README.md
+++ b/nodes/thuroros/README.md
@@ -2,9 +2,11 @@
 
 Special-purpose OS for the **doorbell relay**. A Raspberry Pi 4 (`thuroros`)
 watches a physical doorbell button and, when it is pressed, notifies my phone.
-The Pi has no notification capability of its own — it hands the message to
+The Pi has no notification capability of its own: it hands the message to
 [mowa](https://github.com/mauromorales/mowa) running on the Mac (`polaris`),
-which relays it through Apple Messages / iMessage.
+which relays it through Apple Messages / iMessage, and it publishes the same
+event to Home Assistant over MQTT (see below), for a local push notification
+and a real entity with history.
 
 ## Architecture
 
@@ -22,6 +24,7 @@ flowchart LR
     end
 
     doorbell -->|"POST /api/messages<br/>{to, message}"| mowa
+    doorbell -->|"MQTT publish<br/>thuroros/doorbell/state"| ha
 
     subgraph polaris["polaris · Mac (macOS)"]
         mowa["mowa :8080<br/>(Go, launchd)"]
@@ -29,11 +32,20 @@ flowchart LR
         mowa -->|osascript / AppleScript| messages
     end
 
+    subgraph haHost["homeassistant · Raspberry Pi 4 (HA OS)"]
+        ha["Mosquitto broker<br/>+ Home Assistant"]
+        entity["event.* (doorbell)"]
+        ha -->|MQTT discovery| entity
+        entity -->|automation| push["notify.mobile_app_*"]
+    end
+
     messages -->|iMessage| phone([My phone])
+    push -->|Local Push, WebSocket| phone
 ```
 
-Both hosts advertise on the LAN over mDNS (avahi / Bonjour), so `thuroros`
-reaches mowa at `polaris.local` — no static IPs.
+All three hosts advertise on the LAN over mDNS (avahi / Bonjour), so `thuroros`
+reaches mowa at `polaris.local` and Home Assistant at `homeassistant.local`:
+no static IPs.
 
 ## The two nodes
 
@@ -47,7 +59,9 @@ services:
   press it reads the current recipient and message from the config file and
   `POST`s them to mowa. It checks the per-recipient `results[].success` in
   mowa's response, and bounds the request with a `(3.05s, 10s)` timeout so a
-  stuck relay can't freeze the button handler.
+  stuck relay can't freeze the button handler. It also publishes the press to
+  Home Assistant over MQTT (see below), independently: a broker outage cannot
+  affect the iMessage path, and a Messages wedge cannot affect MQTT.
 - **`doorbell-web`** — a tiny stdlib HTTP server on `:8080` serving a config
   page at `http://thuroros.local:8080/doorbell`. It lets me switch the recipient
   between the `admin` and `family` groups and change the message text without
@@ -75,7 +89,32 @@ each via `osascript` → AppleScript → Messages.app → iMessage.
 
 End to end this is typically **~0.4s**: GPIO detect ≤0.1s, mowa + AppleScript
 ~0.18s, iMessage delivery ~0.18s. Overall latency is bounded by iMessage, not by
-this pipeline — the local hops are sub-second.
+this pipeline: the local hops are sub-second.
+
+## Home Assistant (MQTT)
+
+On every press, `doorbell` also publishes to the Mosquitto broker on the
+`homeassistant` Pi, independently of the mowa/iMessage path above:
+
+- **Once, retained, at service start**, a discovery message to
+  `homeassistant/event/thuroros_doorbell/config`. Home Assistant reads this and
+  creates the doorbell's `event.*` entity automatically: no manual entity setup
+  on the HA side. (Exact `entity_id` is HA's to assign; check it once this is
+  live rather than assuming the name here.)
+- **On every press**, `{"event_type": "pressed", "message": <text>}` to
+  `thuroros/doorbell/state`. Each press shows up in Home Assistant's Logbook and
+  History like any other entity state change.
+
+An HA automation triggers on that entity and calls `notify.mobile_app_*` for the
+push. That automation lives in Home Assistant's own config, not in this
+repository. Today it's set to **Local Push** only (WebSocket, free, works while
+the phone is on the same Wi-Fi as Home Assistant); remote (away from home) push
+would need Nabu Casa or a VPN back into the LAN, deliberately not set up yet.
+
+**MQTT credentials, if the broker needs them, are never in this file.** They're
+optional fields (`mqtt_user`, `mqtt_password`) in the same persisted
+`config.json` described below, set by hand on the device, not via
+`doorbell-web` or git. `homelab` is public.
 
 ## Configuration
 
@@ -86,16 +125,23 @@ this pipeline — the local hops are sub-second.
 ```
 
 - **`to`** — `admin` or `family` (must match a group defined in mowa).
-- **`message`** — the notification text; defaults to the doorbell message.
+- **`message`** — the notification text; defaults to the doorbell message. Also
+  carried as an attribute on the Home Assistant event.
+- **`mqtt_user`** / **`mqtt_password`** (optional): only needed if the Mosquitto
+  broker requires authentication. Unset means an anonymous MQTT connection.
 
-Change either at `http://thuroros.local:8080/doorbell`.
+`to` and `message` change at `http://thuroros.local:8080/doorbell`.
+`mqtt_user`/`mqtt_password` are edited on the device directly (not exposed in
+`doorbell-web` yet).
 
 ## Operational notes
 
 - **Resilience:** mowa relays *synchronously* through the Messages AppleScript
   bridge, which can occasionally wedge (its default AppleEvent timeout is
   ~120s). The doorbell's request timeout keeps such a wedge from freezing the
-  button handler; it logs a timeout and keeps running.
+  button handler; it logs a timeout and keeps running. The MQTT publish has the
+  same shape: a 5s socket timeout, caught and logged, never raised, so a broker
+  outage cannot freeze the button handler either.
 - **Deployment:** changes to `cloud-config.yaml` trigger an image rebuild
   ([`build-thuroros.yaml`](../../.github/workflows/build-thuroros.yaml)); the
   new image is flashed or upgraded onto the Pi. Releases are cut by tagging

--- a/nodes/thuroros/cloud-config.yaml
+++ b/nodes/thuroros/cloud-config.yaml
@@ -23,8 +23,16 @@ stages:
             import requests
             import json
             import os
+            import socket
             from datetime import datetime
             import pytz
+            import paho.mqtt.publish as mqtt_publish
+
+            # paho's publish.single() has no explicit connect timeout of its own; it
+            # relies on the socket default, which is unbounded unless set here. A
+            # wedged broker must not be able to freeze the button handler, same as
+            # notify()'s bounded POST below.
+            socket.setdefaulttimeout(5)
 
             # GPIO Setup
             GPIO_PIN = 23
@@ -38,6 +46,28 @@ stages:
             DEFAULT_MESSAGE = "🔔 Someone is at the door 🚪"
             ALLOWED_RECIPIENTS = ["admin", "family"]
 
+            # Home Assistant, via MQTT discovery. mqtt_user/mqtt_password are optional
+            # and read from CONFIG_PATH -- never from this file, which is public git
+            # history. Unset means an anonymous connection attempt; if the broker
+            # requires auth and none is configured, publishing just fails and is
+            # logged, the same as any other MQTT outage.
+            MQTT_HOST = "homeassistant.local"
+            MQTT_DISCOVERY_TOPIC = "homeassistant/event/thuroros_doorbell/config"
+            MQTT_STATE_TOPIC = "thuroros/doorbell/state"
+            MQTT_DISCOVERY_PAYLOAD = json.dumps({
+                "name": "Doorbell",
+                "unique_id": "thuroros_doorbell",
+                "state_topic": MQTT_STATE_TOPIC,
+                "event_types": ["pressed"],
+                "device_class": "doorbell",
+                "device": {
+                    "identifiers": ["thuroros"],
+                    "name": "ThurorOS",
+                    "model": "Raspberry Pi 4",
+                    "manufacturer": "Raspberry Pi Foundation",
+                },
+            })
+
             def load_config():
                 """Read the current recipient/message, falling back to defaults."""
                 try:
@@ -50,6 +80,39 @@ stages:
                     to = DEFAULT_TO
                 message = cfg.get("message") or DEFAULT_MESSAGE
                 return to, message
+
+            def mqtt_auth():
+                """Optional MQTT credentials, from the same persisted config as
+                to/message. None until someone sets them on the device, which keeps
+                this a safe no-op against a broker that needs auth and has none yet."""
+                try:
+                    with open(CONFIG_PATH) as f:
+                        cfg = json.load(f)
+                except (FileNotFoundError, json.JSONDecodeError, OSError):
+                    return None
+                user = cfg.get("mqtt_user")
+                if not user:
+                    return None
+                return {"username": user, "password": cfg.get("mqtt_password", "")}
+
+            def mqtt_publish_safe(topic, payload, retain=False):
+                """One bounded MQTT publish. Never allowed to affect the iMessage
+                path below -- same resilience shape as notify()'s POST: log and
+                move on, never raise."""
+                try:
+                    mqtt_publish.single(
+                        topic, payload=payload, hostname=MQTT_HOST, retain=retain,
+                        auth=mqtt_auth(),
+                    )
+                except Exception as e:
+                    print(f"⚠️ MQTT publish to {topic} failed: {e}")
+
+            def announce_doorbell_to_ha():
+                """Retained discovery message. Home Assistant creates the doorbell's
+                event entity the moment this lands (exact entity_id is HA's to pick,
+                confirm it once this is live); harmless to repeat on every service
+                start."""
+                mqtt_publish_safe(MQTT_DISCOVERY_TOPIC, MQTT_DISCOVERY_PAYLOAD, retain=True)
 
             def notify(to, message):
                 """Send a doorbell message to mowa which sends it to my phone."""
@@ -101,6 +164,7 @@ stages:
                     print(f"❌ Unexpected error: {e}")
 
             print("🚀 Doorbell monitor started...")
+            announce_doorbell_to_ha()
             while True:
                 if GPIO.gpio_read(h, GPIO_PIN) == 0:  # Button pressed
                     to, message = load_config()
@@ -108,6 +172,7 @@ stages:
                     timestamp = datetime.now(brussels_tz).strftime("%Y-%m-%d %H:%M:%S")
                     print(f"[{timestamp}] {message} -> {to}")
                     notify(to, message)
+                    mqtt_publish_safe(MQTT_STATE_TOPIC, json.dumps({"event_type": "pressed", "message": message}))
                     time.sleep(2)  # Avoid spamming messages
                 time.sleep(0.1)
     - name: "Create doorbell config web UI script"


### PR DESCRIPTION
Part of [mauromorales/mission-control#335](https://github.com/mauromorales/mission-control/issues/335) (private steering repo). Design discussed interactively with Mauro on 2026-08-21: MQTT via Home Assistant's `event` platform with discovery, Local Push notification only for now (free, no Nabu Casa).

## What changes

- `Dockerfile`: adds `python3-paho-mqtt` (confirmed present in Ubuntu 22.04 jammy universe).
- `cloud-config.yaml`: the `doorbell` service now publishes to the Mosquitto broker on `homeassistant.local`, independently of the existing mowa/iMessage path:
  - once, retained, at service start: an MQTT discovery message so Home Assistant creates the doorbell's `event.*` entity with no manual HA-side setup
  - on every press: `{"event_type": "pressed", "message": <text>}`
  - bounded with a 5s socket timeout, caught and logged, never raised, so an MQTT outage cannot freeze the button handler (same resilience shape as the existing bounded POST to mowa)
- `README.md`: documents the new path, updates the architecture diagram, notes where MQTT credentials live if the broker needs them (never in this file, `homelab` is public).

## What this does NOT do

- No Home Assistant automation. That's Mauro's to set up in the HA UI once the entity exists; tracked separately.
- No change to `doorbell-web`. MQTT credentials, if needed, go straight into the device's existing persisted `config.json` (`mqtt_user`/`mqtt_password`), not exposed in the web form yet.
- No deploy. Merging this doesn't touch the running Pi; that needs a release tag per the existing `release.yaml` flow, and a manual flash/upgrade.

## Verified before writing this

- `python3-paho-mqtt` is a real Ubuntu 22.04 jammy package (checked against packages.ubuntu.com).
- Mosquitto is running and reachable: Mauro confirmed via the HA UI (MQTT integration configured) and `nc -zv homeassistant.local 1883` connecting.
- YAML parses, and the embedded Python compiles (`py_compile`) — lgpio/paho-mqtt themselves aren't installable in this sandbox to actually run it, so this is a syntax check, not a live test on hardware.
